### PR TITLE
Add opt-in multi-tier additional seats flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Wicket Account Centre Changelog
 
+# 1.7.1 / 2026-06-25
+- Added opt-in multi-tier additional seats flow for orgs holding several active membership tiers at once (e.g. ESCRS). Tier mode activates via `additional_seats.tier_mode` / `tier_skus` config; legacy single-SKU sites are unaffected.
+- Tier-specific WooCommerce product resolution per membership tier slug, derived as `{sku_prefix}-{tier-slug}` or mapped explicitly via `tier_skus`.
+- Per-line-item MDP-only fulfilment on order completion: bumps the correct `organization_memberships.max_assignments` per line item, with per-item idempotency (`tier_seats_applied`) and partial-fulfilment retry safety (`tier_seats_partial`).
+- Gravity Form tier-slug hidden field + per-tier quantity inputs support; form resolved by slug via `wicket_gf_get_form_id_by_slug()`.
+- Admin setup-warning card now shows expected form slug and tier-slug field parameter with explanations.
+- Fixed partial MDP failure permanently dropping unfulfilled tier items.
+- Preserved legacy single-SKU quantity cap of 100 on legacy sites; tier-mode fields honour configured `max_quantity`.
+
 # 1.5.64 / 2024-10-18
 - Available classes to hide elements based on existing memberships.
 - Avoid loading assets when we are not viewing an ACC related page.

--- a/README.txt
+++ b/README.txt
@@ -4,6 +4,7 @@ Tags: wicket, account centre
 Requires at least: 6.4
 Tested up to: 6.6
 Requires PHP: 8.1
+Stable tag: 1.7.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/class-wicket-acc-main.php
+++ b/class-wicket-acc-main.php
@@ -16,7 +16,7 @@ use WicketORM\OrgMan;
  * Plugin Name:       Wicket Account Centre
  * Plugin URI:        https://wicket.io
  * Description:       Custom account management system for Wicket. Provides user account features, organization management, and additional blocks and pages. Integrates with WooCommerce when available.
- * Version:           1.7.0
+ * Version:           1.7.1
  * Author:            Wicket Inc.
  * Developed By:      Wicket Inc.
  * Author URI:        https://wicket.io

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "industrialdev/wicket-wp-account-centre",
     "description": "Wicket's Account Centre for WordPress",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "extra": {},
     "homepage": "https://wicket.io",
     "keywords": [

--- a/src/WicketORM/Config/OrgManConfig.php
+++ b/src/WicketORM/Config/OrgManConfig.php
@@ -405,6 +405,17 @@ final class OrgManConfig
                     'form_slug' => 'additional-seats',
                     'min_quantity' => 1,
                     'max_quantity' => 900,
+                    // Multi-tier seat purchases (opt-in). When tier_mode is true (or tier_skus is
+                    // non-empty) the additional-seats flow resolves one WooCommerce product per
+                    // membership tier slug instead of a single shared product. Sites that hold
+                    // more than one org membership tier at once (e.g. ESCRS) use this so each
+                    // purchase targets the correct membership record. Legacy single-SKU sites
+                    // leave this off and keep the existing behaviour.
+                    'tier_mode' => false,
+                    'tier_skus' => [
+                        // 'tier-slug' => 'tier-specific-sku',
+                    ],
+                    'tier_slug_field' => 'tier-slug',
                 ],
                 'documents' => [
                     'allowed_types' => [

--- a/src/WicketORM/Helpers/GravityFormsHelper.php
+++ b/src/WicketORM/Helpers/GravityFormsHelper.php
@@ -111,6 +111,19 @@ class GravityFormsHelper extends Helper
             'seat_quantity' => (int) $seat_quantity,
         ]));
 
+        // Multi-tier: resolve the tier slug and, when present, the per-tier quantity.
+        $tier_slug = '';
+        $tiered_service = new \WicketORM\Services\AdditionalSeatsService($configService);
+        if ($tiered_service->isTierMode()) {
+            $tier_slug = self::get_request_tier_slug($field_map);
+            if ($tier_slug !== '') {
+                $tier_qty = self::resolve_seat_quantity_for_tier($field_map, $tier_slug);
+                if ($tier_qty > 0) {
+                    $seat_quantity = $tier_qty;
+                }
+            }
+        }
+
         // Validate required fields
         if (empty($org_uuid) || empty($membership_id) || empty($seat_quantity)) {
             self::log_error('Missing required fields in additional seats submission', [
@@ -132,12 +145,14 @@ class GravityFormsHelper extends Helper
             'org_uuid' => sanitize_text_field($org_uuid),
             'membership_id' => sanitize_text_field($membership_id),
             'seat_quantity' => absint($seat_quantity),
+            'tier_slug' => $tier_slug !== '' ? sanitize_text_field($tier_slug) : '',
         ];
 
         $logger->info('[OrgMan] Stored Gravity Forms additional seats submission in session', array_merge($context, [
             'org_uuid' => sanitize_text_field($org_uuid),
             'membership_id' => sanitize_text_field($membership_id),
             'seat_quantity' => absint($seat_quantity),
+            'tier_slug' => $tier_slug !== '' ? sanitize_text_field($tier_slug) : '',
         ]));
     }
 
@@ -178,11 +193,23 @@ class GravityFormsHelper extends Helper
 
         // Get the additional seats product
         $additional_seats_service = new \WicketORM\Services\AdditionalSeatsService($configService);
-        $product_id = $additional_seats_service->getAdditionalSeatsProduct();
+        $tier_slug = is_array($seat_data) && !empty($seat_data['tier_slug']) ? sanitize_text_field((string) $seat_data['tier_slug']) : '';
+
+        // Multi-tier: resolve the tier-specific product; fall back to the legacy single product
+        // when tier mode is off or no tier slug was captured.
+        $product_id = 0;
+        if ($tier_slug !== '' && $additional_seats_service->isTierMode()) {
+            $product_id = (int) $additional_seats_service->getAdditionalSeatsProductForTier($tier_slug);
+        }
+        if (!$product_id) {
+            $product_id = (int) $additional_seats_service->getAdditionalSeatsProduct();
+        }
 
         if (!$product_id) {
             wc_add_notice(__('Additional seats product not found. Please contact support.', 'wicket-acc'), 'error');
-            $logger->error('[OrgMan] Additional seats product missing during Gravity Forms confirmation', $context);
+            $logger->error('[OrgMan] Additional seats product missing during Gravity Forms confirmation', array_merge($context, [
+                'tier_slug' => $tier_slug,
+            ]));
 
             return $confirmation;
         }
@@ -206,6 +233,7 @@ class GravityFormsHelper extends Helper
             [
                 'org_uuid' => $seat_data['org_uuid'],
                 'membership_id' => $seat_data['membership_id'],
+                'tier_slug' => $tier_slug,
                 'additional_seats' => true,
             ]
         );
@@ -291,6 +319,18 @@ class GravityFormsHelper extends Helper
         }
 
         $quantity = absint($seat_quantity);
+
+        // Multi-tier: resolve tier slug + per-tier quantity, overriding the generic quantity.
+        $tier_slug = '';
+        $tiered_service = new \WicketORM\Services\AdditionalSeatsService($configService);
+        if ($tiered_service->isTierMode()) {
+            $tier_slug = self::get_request_tier_slug($field_map);
+            if ($tier_slug !== '') {
+                $tier_qty = self::resolve_seat_quantity_for_tier($field_map, $tier_slug);
+                $quantity = absint($tier_qty);
+            }
+        }
+
         if ($org_uuid === '' || $membership_id === '' || $quantity < 1) {
             return $form;
         }
@@ -299,6 +339,7 @@ class GravityFormsHelper extends Helper
             'org_uuid' => sanitize_text_field($org_uuid),
             'membership_id' => sanitize_text_field($membership_id),
             'seat_quantity' => $quantity,
+            'tier_slug' => $tier_slug !== '' ? sanitize_text_field($tier_slug) : '',
         ];
 
         $user_id = get_current_user_id();
@@ -307,6 +348,7 @@ class GravityFormsHelper extends Helper
                 'org_uuid' => sanitize_text_field($org_uuid),
                 'membership_id' => sanitize_text_field($membership_id),
                 'seat_quantity' => $quantity,
+                'tier_slug' => $tier_slug !== '' ? sanitize_text_field($tier_slug) : '',
                 'created_at' => current_time('mysql'),
             ]);
         }
@@ -330,6 +372,80 @@ class GravityFormsHelper extends Helper
         }
 
         return is_string($value) ? $value : '';
+    }
+
+    /**
+     * Resolve the membership tier slug from the current request (multi-tier mode).
+     *
+     * Order: posted GF hidden field (mapped tier_slug field) -> configured query/post field name
+     * -> 'tier_slug'/'tier-slug' aliases -> stored purchase user meta.
+     *
+     * @param array $field_map Field map from get_additional_seats_field_map().
+     * @return string Tier slug, or '' when not present.
+     */
+    private static function get_request_tier_slug(array $field_map): string
+    {
+        $configService = new \WicketORM\Services\ConfigService();
+        $tier_slug_field = $configService->getAdditionalSeatsTierSlugField();
+
+        if (!empty($field_map['tier_slug'])) {
+            $value = self::get_posted_field_value((int) $field_map['tier_slug']);
+            if ($value !== '') {
+                return sanitize_text_field($value);
+            }
+        }
+
+        foreach (array_unique(array_filter([$tier_slug_field, 'tier_slug', 'tier-slug'])) as $key) {
+            if (isset($_POST[$key])) {
+                $value = sanitize_text_field(wp_unslash($_POST[$key]));
+                if ($value !== '') {
+                    return $value;
+                }
+            }
+            if (isset($_GET[$key])) {
+                $value = sanitize_text_field(wp_unslash($_GET[$key]));
+                if ($value !== '') {
+                    return $value;
+                }
+            }
+        }
+
+        $additional_seats_service = new \WicketORM\Services\AdditionalSeatsService($configService);
+        $purchase_meta = $additional_seats_service->getPurchaseUserMeta();
+        if (is_array($purchase_meta) && !empty($purchase_meta['tier_slug'])) {
+            return sanitize_text_field((string) $purchase_meta['tier_slug']);
+        }
+
+        return '';
+    }
+
+    /**
+     * Resolve the seat quantity for a given tier slug from the current request (multi-tier mode).
+     *
+     * Reads the per-tier number field (inputName 'seat_quantity_{tier-slug}') when mapped, with a
+     * fallback to the generic 'seat_quantity' field. Returns the raw integer (callers validate).
+     *
+     * @param array  $field_map Field map from get_additional_seats_field_map().
+     * @param string $tier_slug Membership tier slug.
+     * @return int Parsed quantity (may be 0/negative; callers must validate >= 1).
+     */
+    private static function resolve_seat_quantity_for_tier(array $field_map, string $tier_slug): int
+    {
+        $tier_slug = trim($tier_slug);
+        $candidate_field_id = null;
+        if ($tier_slug !== '' && isset($field_map['seat_quantities'][$tier_slug])) {
+            $candidate_field_id = (int) $field_map['seat_quantities'][$tier_slug];
+        } elseif (!empty($field_map['seat_quantity'])) {
+            $candidate_field_id = (int) $field_map['seat_quantity'];
+        }
+
+        if ($candidate_field_id) {
+            $value = self::get_posted_field_value($candidate_field_id);
+
+            return (int) $value;
+        }
+
+        return 0;
     }
 
     /**
@@ -385,21 +501,45 @@ class GravityFormsHelper extends Helper
         $configService = new \WicketORM\Services\ConfigService();
         $additional_seats_form_id = $configService->getAdditionalSeatsFormId();
 
-        $field_map = self::get_additional_seats_field_map($form);
-        $quantity_field_id = $field_map['seat_quantity'] ?? null;
-
-        if ($form['id'] !== $additional_seats_form_id || !$quantity_field_id || (int) $field->id !== (int) $quantity_field_id) {
+        if ($form['id'] !== $additional_seats_form_id) {
             return $result;
         }
 
+        $field_map = self::get_additional_seats_field_map($form);
+        $min = (int) $configService->getAdditionalSeatsMinQuantity();
+        if ($min < 1) {
+            $min = 1;
+        }
+
+        // Legacy single quantity field.
+        $quantity_field_id = $field_map['seat_quantity'] ?? null;
+        $is_legacy_field = $quantity_field_id && (int) $field->id === (int) $quantity_field_id;
+
+        // Multi-tier per-tier quantity field.
+        $tier_quantity_field_ids = isset($field_map['seat_quantities']) && is_array($field_map['seat_quantities'])
+            ? array_map('intval', array_values($field_map['seat_quantities']))
+            : [];
+        $is_tier_field = in_array((int) $field->id, $tier_quantity_field_ids, true);
+
+        if (!$is_legacy_field && !$is_tier_field) {
+            return $result;
+        }
+
+        // Legacy single-SKU sites keep the historical hard cap of 100 (B1: do not silently widen
+        // to the configured max_quantity, whose default is 900). Tier-mode fields honour the
+        // configured max_quantity instead.
+        $max = $is_tier_field ? (int) $configService->getAdditionalSeatsMaxQuantity() : 100;
+
         $quantity = absint($value);
 
-        if ($quantity < 1) {
+        if ($quantity < $min) {
             $result['is_valid'] = false;
-            $result['message'] = __('Please enter at least 1 seat.', 'wicket-acc');
-        } elseif ($quantity > 100) {
+            /* translators: %d: minimum seats per order */
+            $result['message'] = sprintf(__('Please enter at least %d seat(s).', 'wicket-acc'), $min);
+        } elseif ($max > 0 && $quantity > $max) {
             $result['is_valid'] = false;
-            $result['message'] = __('Maximum 100 seats can be purchased at once. Please contact support for larger orders.', 'wicket-acc');
+            /* translators: %d: maximum seats per order */
+            $result['message'] = sprintf(__('Maximum %d seats can be purchased at once. Please contact support for larger orders.', 'wicket-acc'), $max);
         }
 
         return $result;
@@ -436,11 +576,13 @@ class GravityFormsHelper extends Helper
     /**
      * Get form HTML for additional seats.
      *
-     * @param string $org_uuid The organization UUID.
+     * @param string $org_uuid      The organization UUID.
      * @param string $membership_id The membership ID.
+     * @param string $tier_slug     Optional membership tier slug (multi-tier mode) used to populate
+     *                              the tier-slug hidden field and drive GF conditional logic.
      * @return string The form HTML or empty string if form not found.
      */
-    public static function get_form_html($org_uuid, $membership_id)
+    public static function get_form_html($org_uuid, $membership_id, $tier_slug = '')
     {
         $configService = new \WicketORM\Services\ConfigService();
         $form_id = $configService->getAdditionalSeatsFormIdForCurrentLanguage();
@@ -458,9 +600,28 @@ class GravityFormsHelper extends Helper
             return '';
         }
 
+        $tier_slug = is_string($tier_slug) ? trim($tier_slug) : '';
+        // Multi-tier: when no explicit tier slug was passed, read it from the request so the
+        // form renders with the correct conditional input visible.
+        if ($tier_slug === '') {
+            $tier_slug_field = $configService->getAdditionalSeatsTierSlugField();
+            foreach (array_unique(array_filter([$tier_slug_field, 'tier_slug', 'tier-slug'])) as $key) {
+                if (isset($_GET[$key])) {
+                    $candidate = sanitize_text_field(wp_unslash($_GET[$key]));
+                    if ($candidate !== '') {
+                        $tier_slug = $candidate;
+                        break;
+                    }
+                }
+            }
+        }
+
         // Set default values for hidden fields
         $_GET['org_uuid'] = $org_uuid;
         $_GET['membership_id'] = $membership_id;
+        if ($tier_slug !== '') {
+            $_GET[$configService->getAdditionalSeatsTierSlugField()] = $tier_slug;
+        }
 
         $previous_lang = null;
         $current_lang = function_exists('wicket_get_current_language') ? wicket_get_current_language() : null;
@@ -475,6 +636,10 @@ class GravityFormsHelper extends Helper
             'org_uuid' => $org_uuid,
             'membership_id' => $membership_id,
         ];
+        if ($tier_slug !== '') {
+            $field_values[$configService->getAdditionalSeatsTierSlugField()] = $tier_slug;
+            $field_values['tier_slug'] = $tier_slug;
+        }
 
         // Render the form without AJAX to preserve Woo session/cart cookies.
         ob_start();
@@ -588,6 +753,12 @@ class GravityFormsHelper extends Helper
             return $map;
         }
 
+        $configService = new \WicketORM\Services\ConfigService();
+        $tier_slug_field = $configService->getAdditionalSeatsTierSlugField();
+        $tier_mode = $configService->isAdditionalSeatsTierMode();
+
+        $map['seat_quantities'] = [];
+
         foreach ($form['fields'] as $field) {
             if (!isset($field->id)) {
                 continue;
@@ -605,6 +776,19 @@ class GravityFormsHelper extends Helper
                 if ($input_name === 'membership_id' || $admin_label === 'membership_id' || $label === 'membership_id') {
                     $map['membership_id'] = (int) $field->id;
                 }
+                // Multi-tier tier-slug hidden field. Recognizes the configured slug field name plus
+                // common aliases so the same helper works regardless of GF field naming.
+                if (
+                    $input_name === $tier_slug_field
+                    || $input_name === 'tier_slug'
+                    || $admin_label === 'tier_slug'
+                    || $admin_label === 'tier-slug'
+                    || $label === 'Tier Slug'
+                    || $label === 'tier-slug'
+                    || $label === 'tier_slug'
+                ) {
+                    $map['tier_slug'] = (int) $field->id;
+                }
             }
 
             if ($field->type === 'number') {
@@ -615,7 +799,27 @@ class GravityFormsHelper extends Helper
                 } elseif ($label === 'Number of Additional Seats') {
                     $map['seat_quantity'] = (int) $field->id;
                 }
+
+                // Multi-tier per-tier quantity fields: inputName 'seat_quantity_{tier-slug}'.
+                if ($input_name !== '' && str_starts_with($input_name, 'seat_quantity_')) {
+                    $tier_slug_for_field = substr($input_name, strlen('seat_quantity_'));
+                    $tier_slug_for_field = is_string($tier_slug_for_field) ? trim($tier_slug_for_field) : '';
+                    if ($tier_slug_for_field !== '') {
+                        $map['seat_quantities'][$tier_slug_for_field] = (int) $field->id;
+                    }
+                }
             }
+        }
+
+        // Drop the per-tier bucket when empty to keep the map shape clean for legacy callers.
+        if (empty($map['seat_quantities'])) {
+            unset($map['seat_quantities']);
+        }
+
+        // In tier mode, record the active mode on the map so callers can branch without
+        // re-querying config.
+        if ($tier_mode) {
+            $map['tier_mode'] = true;
         }
 
         return $map;
@@ -678,6 +882,7 @@ class GravityFormsHelper extends Helper
         $org_uuid = isset($pending['org_uuid']) ? sanitize_text_field((string) $pending['org_uuid']) : '';
         $membership_id = isset($pending['membership_id']) ? sanitize_text_field((string) $pending['membership_id']) : '';
         $seat_quantity = isset($pending['seat_quantity']) ? absint($pending['seat_quantity']) : 0;
+        $pending_tier_slug = isset($pending['tier_slug']) ? sanitize_text_field((string) $pending['tier_slug']) : '';
         if ($org_uuid === '' || $membership_id === '' || $seat_quantity < 1) {
             $logger->warning('[OrgMan] Pending additional seats data invalid', [
                 'source' => 'wicket-orgman',
@@ -692,12 +897,19 @@ class GravityFormsHelper extends Helper
 
         $configService = new \WicketORM\Services\ConfigService();
         $additional_seats_service = new \WicketORM\Services\AdditionalSeatsService($configService);
-        $product_id = $additional_seats_service->getAdditionalSeatsProduct();
+        $product_id = 0;
+        if ($pending_tier_slug !== '' && $additional_seats_service->isTierMode()) {
+            $product_id = (int) $additional_seats_service->getAdditionalSeatsProductForTier($pending_tier_slug);
+        }
+        if (!$product_id) {
+            $product_id = (int) $additional_seats_service->getAdditionalSeatsProduct();
+        }
         if (!$product_id) {
             wc_add_notice(__('Additional seats product not found. Please contact support.', 'wicket-acc'), 'error');
             $logger->error('[OrgMan] Additional seats product missing during restore', [
                 'source' => 'wicket-orgman',
                 'user_id' => $user_id,
+                'tier_slug' => $pending_tier_slug,
             ]);
 
             return;
@@ -716,6 +928,7 @@ class GravityFormsHelper extends Helper
             [
                 'org_uuid' => $org_uuid,
                 'membership_id' => $membership_id,
+                'tier_slug' => $pending_tier_slug,
                 'additional_seats' => true,
             ]
         );

--- a/src/WicketORM/OrgMan.php
+++ b/src/WicketORM/OrgMan.php
@@ -335,6 +335,21 @@ final class OrgMan
 
         // Check if this is an additional seats order
         $additional_seats_service = $this->services['additional_seats'];
+
+        // Multi-tier path: when tier mode is active and the order contains any tier-specific
+        // seat product, fulfil per line item via MDP only (no subscription/CPT), then return.
+        // This keeps multi-membership orgs (e.g. ESCRS) isolated from the legacy subscription
+        // flow while leaving single-SKU sites on the unchanged path below.
+        if ($additional_seats_service->isTierMode() && $this->orderHasTierSeatItems($order)) {
+            $processed = $this->processTierSeatLineItems($order);
+            $logger->info('Tier-mode additional seats processing complete', array_merge($context, [
+                'order_id' => $order_id,
+                'processed_items' => $processed,
+            ]));
+
+            return;
+        }
+
         $additional_seats_product_id = $additional_seats_service->getAdditionalSeatsProduct();
 
         if (!$additional_seats_product_id) {
@@ -814,6 +829,26 @@ final class OrgMan
             return false;
         }
 
+        // Multi-tier: any tier-specific seat product qualifies the order.
+        if ($additional_seats_service->isTierMode()) {
+            foreach ($order->get_items() as $item) {
+                $product = $item->get_product();
+                if (!$product) {
+                    continue;
+                }
+                $tier_slug = $additional_seats_service->classifySeatProduct((int) $product->get_id());
+                if ($tier_slug !== null) {
+                    $logger->debug('Tier seat product detected on order', array_merge($context, [
+                        'order_id' => (int) $order->get_id(),
+                        'order_item_id' => $item->get_id(),
+                        'tier_slug' => $tier_slug,
+                    ]));
+
+                    return true;
+                }
+            }
+        }
+
         $product_id = $additional_seats_service->getAdditionalSeatsProduct();
         if (!$product_id) {
             $logger->error('Additional seats product not found; cannot detect additional seats order', array_merge($context, [
@@ -878,6 +913,179 @@ final class OrgMan
         }
 
         return $base_url;
+    }
+
+    /**
+     * Whether an order contains any tier-specific seat line item (multi-tier mode).
+     *
+     * @param \WC_Order $order WooCommerce order.
+     * @return bool
+     */
+    private function orderHasTierSeatItems($order): bool
+    {
+        $additional_seats_service = $this->services['additional_seats'] ?? null;
+        if (!$additional_seats_service || !$additional_seats_service->isTierMode()) {
+            return false;
+        }
+
+        foreach ($order->get_items() as $item) {
+            $product = $item->get_product();
+            if (!$product) {
+                continue;
+            }
+            if ($additional_seats_service->classifySeatProduct((int) $product->get_id()) !== null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Fulfil tier-mode additional seats per line item via the MDP only.
+     *
+     * For each tier seat line item: read its quantity and stamped org_uuid/membership_id, then
+     * raise that organization membership's max_assignments by the purchased quantity. No
+     * WooCommerce Subscription, wicket_membership CPT, or Membership_Controller interaction
+     * occurs here. Per-item idempotency meta ('tier_seats_applied') makes re-runs safe.
+     *
+     * @param \WC_Order $order WooCommerce order.
+     * @return int Number of line items successfully fulfilled.
+     */
+    private function processTierSeatLineItems($order): int
+    {
+        $logger = \Wicket()->log();
+        $context = ['source' => 'wicket-orgman', 'order_id' => (int) $order->get_id()];
+        $additional_seats_service = $this->services['additional_seats'];
+        $fulfilled = 0;
+        $total_tier_items = 0;
+
+        foreach ($order->get_items() as $item) {
+            $product = $item->get_product();
+            if (!$product) {
+                continue;
+            }
+
+            $tier_slug = $additional_seats_service->classifySeatProduct((int) $product->get_id());
+            if ($tier_slug === null) {
+                continue;
+            }
+
+            $total_tier_items++;
+
+            // Idempotency: skip items already applied.
+            if ($item->get_meta('tier_seats_applied', true)) {
+                $logger->debug('Tier seat item already applied; skipping', array_merge($context, [
+                    'order_item_id' => $item->get_id(),
+                    'tier_slug' => $tier_slug,
+                ]));
+
+                continue;
+            }
+
+            $membership_id = (string) $item->get_meta('membership_id', true);
+            $org_uuid = (string) $item->get_meta('org_uuid', true);
+            $qty = (int) $item->get_quantity();
+
+            if ($membership_id === '' || $qty < 1) {
+                $logger->error('Tier seat line item missing membership_id or quantity; skipping', array_merge($context, [
+                    'order_item_id' => $item->get_id(),
+                    'tier_slug' => $tier_slug,
+                    'org_uuid' => $org_uuid,
+                    'membership_id' => $membership_id,
+                    'qty' => $qty,
+                ]));
+
+                continue;
+            }
+
+            $ok = $this->applyTierSeatIncrease($org_uuid, $membership_id, $qty);
+            if ($ok) {
+                $item->update_meta_data('tier_seats_applied', true);
+                $item->update_meta_data('tier_seats_applied_qty', $qty);
+                $item->save();
+                $fulfilled++;
+            }
+        }
+
+        // Only mark the order fully processed when EVERY tier line item has been fulfilled.
+        // Per-item 'tier_seats_applied' meta governs re-entry safety, so partial fulfilment
+        // (e.g. one MDP PATCH failing) leaves the order un-stamped and eligible for retry on the
+        // next order-status hook. Without this, a single failure would permanently drop the
+        // unfulfilled items even though the customer paid.
+        if ($total_tier_items > 0 && $fulfilled >= $total_tier_items) {
+            $order->update_meta_data('additional_seats_processed', true);
+            $order->update_meta_data('tier_seats_processed', true);
+            $order->save();
+        } elseif ($fulfilled > 0 && $fulfilled < $total_tier_items) {
+            // Partial fulfilment: do NOT set the order-level guard. Log so retries are traceable.
+            $order->update_meta_data('tier_seats_partial', true);
+            $order->save();
+            $logger->warning('Tier seat fulfilment partial; order left eligible for retry', array_merge($context, [
+                'fulfilled' => $fulfilled,
+                'total_tier_items' => $total_tier_items,
+            ]));
+        }
+
+        $logger->info('Tier seat line items processed', array_merge($context, [
+            'fulfilled' => $fulfilled,
+            'total_tier_items' => $total_tier_items,
+        ]));
+
+        return $fulfilled;
+    }
+
+    /**
+     * Raise an organization membership's max_assignments by a purchased quantity via the MDP.
+     *
+     * Reads the current max_assignments, adds the purchased seats, and PATCHes the membership.
+     *
+     * @param string $org_uuid      Organization UUID (contextual logging).
+     * @param string $membership_id Organization membership UUID.
+     * @param int    $qty           Seats purchased.
+     * @return bool True when the MDP was updated.
+     */
+    private function applyTierSeatIncrease(string $org_uuid, string $membership_id, int $qty): bool
+    {
+        $logger = \Wicket()->log();
+        $context = [
+            'source' => 'wicket-orgman',
+            'org_uuid' => $org_uuid,
+            'membership_id' => $membership_id,
+            'qty' => $qty,
+        ];
+
+        /** @var \WicketORM\Services\AdditionalSeatsService $service */
+        $service = $this->services['additional_seats'];
+
+        $current = $service->getMembershipCurrentMaxAssignments($membership_id);
+        if ($current === null) {
+            $logger->error('Could not read current max_assignments; aborting tier seat increase', $context);
+
+            return false;
+        }
+
+        $new_max = $current + $qty;
+
+        $logger->info('Applying tier seat increase', array_merge($context, [
+            'current_max_assignments' => $current,
+            'new_max_assignments' => $new_max,
+        ]));
+
+        $ok = $service->updateMdpMembershipMaxAssignments($membership_id, $new_max);
+        if (!$ok) {
+            $logger->error('MDP max_assignments update failed for tier seat increase', array_merge($context, [
+                'new_max_assignments' => $new_max,
+            ]));
+
+            return false;
+        }
+
+        $logger->info('Tier seat increase applied', array_merge($context, [
+            'new_max_assignments' => $new_max,
+        ]));
+
+        return true;
     }
 
     /**
@@ -1233,6 +1441,60 @@ final class OrgMan
     public function addAdditionalSeatsDataToOrderItem($item, $cart_item_key, $values, $order)
     {
         $additional_seats_service = $this->services['additional_seats'];
+        $logger = \Wicket()->log();
+
+        $product = $item->get_product();
+        if (!$product) {
+            return;
+        }
+        $product_id = (int) $product->get_id();
+
+        // --- Multi-tier path: classify the line item as a tier-specific seat product. ---
+        // Truth comes from the cart item data ($values), not user meta, because an org may hold
+        // several memberships and a single user-meta record cannot represent them all.
+        if ($additional_seats_service->isTierMode()) {
+            $tier_slug = $additional_seats_service->classifySeatProduct($product_id);
+            if ($tier_slug !== null) {
+                $org_uuid = isset($values['org_uuid']) ? sanitize_text_field((string) $values['org_uuid']) : '';
+                $membership_id = isset($values['membership_id']) ? sanitize_text_field((string) $values['membership_id']) : '';
+                $values_tier_slug = isset($values['tier_slug']) ? sanitize_text_field((string) $values['tier_slug']) : '';
+                if ($values_tier_slug === '') {
+                    $values_tier_slug = $tier_slug;
+                }
+
+                if ($org_uuid === '' || $membership_id === '') {
+                    $logger->warning('Tier seat line item missing org_uuid/membership_id cart data', [
+                        'source' => 'wicket-orgman',
+                        'order_id' => $order->get_id(),
+                        'item_id' => $item->get_id(),
+                        'product_id' => $product_id,
+                        'tier_slug' => $values_tier_slug,
+                    ]);
+
+                    return;
+                }
+
+                $item->update_meta_data('org_uuid', $org_uuid);
+                $item->update_meta_data('_org_uuid', $org_uuid);
+                $item->update_meta_data('membership_id', $membership_id);
+                $item->update_meta_data('tier_slug', $values_tier_slug);
+                $item->update_meta_data('additional_seats', true);
+
+                $logger->info('Stamped tier seat data on order item', [
+                    'source' => 'wicket-orgman',
+                    'order_id' => $order->get_id(),
+                    'item_id' => $item->get_id(),
+                    'product_id' => $product_id,
+                    'org_uuid' => $org_uuid,
+                    'membership_id' => $membership_id,
+                    'tier_slug' => $values_tier_slug,
+                ]);
+
+                return;
+            }
+        }
+
+        // --- Legacy single-SKU path (unchanged). ---
         $additional_seats_product_id = $additional_seats_service->getAdditionalSeatsProduct();
 
         if (!$additional_seats_product_id) {
@@ -1240,8 +1502,7 @@ final class OrgMan
         }
 
         // Check if this is an additional seats product
-        $product = $item->get_product();
-        if (!$product || $product->get_id() !== $additional_seats_product_id) {
+        if ($product_id !== $additional_seats_product_id) {
             return;
         }
 
@@ -1250,7 +1511,6 @@ final class OrgMan
         $user_meta_data = $additional_seats_service->getPurchaseUserMeta($user_id);
 
         if (!$user_meta_data) {
-            $logger = \Wicket()->log();
             $logger->warning('No user meta data found for additional seats order item', [
                 'source' => 'wicket-orgman',
                 'user_id' => $user_id,

--- a/src/WicketORM/Services/AdditionalSeatsService.php
+++ b/src/WicketORM/Services/AdditionalSeatsService.php
@@ -22,6 +22,13 @@ class AdditionalSeatsService
     private $configService;
 
     /**
+     * Memoized tier_slug => product_id map (S3). Null until first resolution.
+     *
+     * @var array<string,int>|null
+     */
+    private $tierProductIdsCache;
+
+    /**
      * Constructor.
      *
      * @param ConfigService $configService The configuration service.
@@ -87,6 +94,34 @@ class AdditionalSeatsService
                 }
                 $parts[] = ['type' => 'text', 'value' => __(' and set it to Published/Purchasable.', 'wicket-acc')];
                 $issues[] = ['parts' => $parts];
+            }
+
+            // Multi-tier: each configured tier SKU must resolve to a purchasable product. When
+            // tier mode is active the single-SKU check above is informational; this block is the
+            // authoritative gate.
+            if ($this->isTierMode()) {
+                $tier_skus = $this->configService->getAdditionalSeatsTierSkus();
+                // Flag-only tier mode (S4): tier_mode is on but no tier_skus map is configured.
+                // Order-side product-id classification is disabled in this mode; surface a clear
+                // setup issue so adopters configure the map rather than hitting silent failures.
+                if (empty($tier_skus)) {
+                    $issues[] = ['parts' => [
+                        ['type' => 'text',  'value' => __('Multi-tier additional seats: tier_mode is enabled but no tier_skus map is configured. Add a tier slug to SKU map (or rely on derived SKUs and ensure matching products exist) in the site org-roster config.', 'wicket-acc')],
+                    ]];
+                }
+                foreach ($tier_skus as $tier_slug => $tier_sku) {
+                    $tier_product_id = wc_get_product_id_by_sku($tier_sku);
+                    $tier_product = $tier_product_id ? wc_get_product($tier_product_id) : null;
+                    if (!$tier_product || !$tier_product->is_purchasable()) {
+                        $issues[] = ['parts' => [
+                            ['type' => 'text',  'value' => __('Multi-tier additional seats: no purchasable product found for tier ', 'wicket-acc')],
+                            ['type' => 'token', 'value' => $tier_slug],
+                            ['type' => 'text',  'value' => __(' (expected SKU ', 'wicket-acc')],
+                            ['type' => 'token', 'value' => $tier_sku],
+                            ['type' => 'text',  'value' => __(').', 'wicket-acc')],
+                        ]];
+                    }
+                }
             }
         }
 
@@ -175,6 +210,124 @@ class AdditionalSeatsService
         $product = $this->resolvePurchasableProductBySkus($skus, 'Additional seats discount product');
 
         return (int) ($product['product_id'] ?? 0) ?: null;
+    }
+
+    /**
+     * Whether the multi-tier additional-seats flow is active for this site.
+     *
+     * Thin proxy over ConfigService::isAdditionalSeatsTierMode(). When true the seat purchase
+     * flow resolves one WooCommerce product per membership tier slug; when false the legacy
+     * single-SKU path is used.
+     *
+     * @return bool
+     */
+    public function isTierMode()
+    {
+        return $this->configService->isAdditionalSeatsTierMode();
+    }
+
+    /**
+     * Resolve the tier-specific additional-seats WooCommerce product for a tier slug.
+     *
+     * SKU comes from ConfigService::getAdditionalSeatsTierSkuForSlug() (explicit map or derived
+     * from the configured prefix). Resolution reuses the WPML-aware helper so translated
+     * products are honoured.
+     *
+     * @param string $tier_slug Membership tier slug.
+     * @return int|null Product ID or null when not found / not purchasable.
+     */
+    public function getAdditionalSeatsProductForTier($tier_slug)
+    {
+        $tier_slug = is_string($tier_slug) ? trim($tier_slug) : '';
+        if ($tier_slug === '') {
+            return null;
+        }
+
+        $sku = $this->configService->getAdditionalSeatsTierSkuForSlug($tier_slug);
+        if ($sku === null) {
+            return null;
+        }
+
+        $product = $this->resolvePurchasableProductBySkus([$sku], 'Additional seats tier product (' . $tier_slug . ')');
+
+        return (int) ($product['product_id'] ?? 0) ?: null;
+    }
+
+    /**
+     * Resolve every configured tier seat product as a tier_slug => product_id map.
+     *
+     * Used by setup-issue checks and order-side classification. Only tiers whose SKU resolves
+     * to a purchasable product are included. Memoized per request (S3) because the order
+     * lifecycle calls classifySeatProduct() across multiple passes x N line items.
+     *
+     * @return array<string,int> Map of tier slug => product ID.
+     */
+    public function getAdditionalSeatsTierProductIds()
+    {
+        if (isset($this->tierProductIdsCache)) {
+            return $this->tierProductIdsCache;
+        }
+
+        $tier_skus = $this->configService->getAdditionalSeatsTierSkus();
+        // Flag-only tier mode (empty map) cannot resolve products by id; only SKU-based
+        // derived classification would work there. Return empty so callers fall back to SKU.
+        if (empty($tier_skus) && $this->isTierMode()) {
+            $this->tierProductIdsCache = [];
+
+            return [];
+        }
+
+        $resolved = [];
+        foreach ($tier_skus as $tier_slug => $sku) {
+            $product_id = $this->getAdditionalSeatsProductForTier($tier_slug);
+            if ($product_id) {
+                $resolved[$tier_slug] = (int) $product_id;
+            }
+        }
+
+        $this->tierProductIdsCache = $resolved;
+
+        return $resolved;
+    }
+
+    /**
+     * Classify a WooCommerce product as a tier-specific seat product.
+     *
+     * Returns the tier slug when the product's SKU maps to a configured/derived tier seat
+     * product, or null when it is not a tier seat product (or tier mode is off).
+     *
+     * @param int $product_id WooCommerce product ID.
+     * @return string|null Tier slug, or null.
+     */
+    public function classifySeatProduct($product_id)
+    {
+        $product_id = (int) $product_id;
+        if ($product_id <= 0 || !$this->isTierMode()) {
+            return null;
+        }
+
+        $product = wc_get_product($product_id);
+        if (!$product) {
+            return null;
+        }
+
+        // Direct product-id match against resolved tier products (covers translated products whose
+        // SKU may differ).
+        $tier_products = $this->getAdditionalSeatsTierProductIds();
+        foreach ($tier_products as $tier_slug => $tier_product_id) {
+            if ((int) $tier_product_id === $product_id) {
+                return (string) $tier_slug;
+            }
+        }
+
+        // SKU-based classification.
+        $sku = $product->get_sku();
+        $sku = is_string($sku) ? trim($sku) : '';
+        if ($sku === '') {
+            return null;
+        }
+
+        return $this->configService->getAdditionalSeatsTierSlugForSku($sku);
     }
 
     /**
@@ -833,7 +986,78 @@ class AdditionalSeatsService
             'current_seats' => $membership_data['membership']['current_max_assignments'] ?? 1,
         ];
 
+        // Multi-tier: pass the membership tier slug so the form can drive conditional logic and
+        // so the submission resolves the correct tier-specific WooCommerce product. Stored
+        // alongside the purchase context in user meta for resilience on the order side.
+        $tier_slug = '';
+        if ($this->isTierMode()) {
+            $membershipService = new \WicketORM\Services\MembershipService();
+            $tier_slug = $membershipService->getMembershipTierSlug((string) $org_uuid, (string) $membership_id);
+            if ($tier_slug !== '') {
+                $args[$this->configService->getAdditionalSeatsTierSlugField()] = $tier_slug;
+                $this->storeTierSlugOnPurchaseUserMeta($tier_slug);
+            }
+        }
+
         return add_query_arg($args, $base_url);
+    }
+
+    /**
+     * Stash the resolved tier slug onto the existing purchase user-meta record.
+     *
+     * Best-effort: the multi-tier order flow sources truth from line-item meta, but keeping the
+     * tier slug in user meta aids restore/recovery paths.
+     *
+     * @param string $tier_slug Membership tier slug.
+     * @return void
+     */
+    public function storeTierSlugOnPurchaseUserMeta(string $tier_slug): void
+    {
+        $tier_slug = trim($tier_slug);
+        if ($tier_slug === '') {
+            return;
+        }
+
+        $current_user_id = get_current_user_id();
+        if (!$current_user_id) {
+            return;
+        }
+
+        $existing = $this->getPurchaseUserMeta($current_user_id);
+        if (!is_array($existing)) {
+            return;
+        }
+
+        $existing['tier_slug'] = $tier_slug;
+        update_user_meta($current_user_id, 'orgman_additional_seats_data', $existing);
+    }
+
+    /**
+     * Read the current max_assignments for an organization membership from the MDP API.
+     *
+     * Public read accessor used by the multi-tier order flow when bumping seats per line item.
+     *
+     * @param string $membership_id Organization membership UUID.
+     * @return int|null Current max_assignments, or null when unavailable.
+     */
+    public function getMembershipCurrentMaxAssignments($membership_id): ?int
+    {
+        $membership_id = is_string($membership_id) ? trim($membership_id) : '';
+        if ($membership_id === '') {
+            return null;
+        }
+
+        $data = $this->getMembershipDataFromApi($membership_id);
+        if (!is_array($data)) {
+            return null;
+        }
+
+        $value = $data['attributes']['max_assignments'] ?? null;
+        if ($value === null || !is_numeric($value)) {
+            return null;
+        }
+
+        return (int) $value;
     }
 
     /**

--- a/src/WicketORM/Services/ConfigService.php
+++ b/src/WicketORM/Services/ConfigService.php
@@ -228,6 +228,153 @@ class ConfigService
     }
 
     /**
+     * Whether the multi-tier additional-seats flow is active.
+     *
+     * Tier mode is opt-in. It activates when the 'tier_mode' flag is explicitly true OR when
+     * 'tier_skus' contains at least one tier-to-SKU mapping. When active the flow resolves one
+     * WooCommerce product per membership tier slug; when inactive the legacy single-SKU path is
+     * used (preserving behaviour for ASAE/CITT/NJBIA/OSPE and similar sites).
+     *
+     * @return bool
+     */
+    public function isAdditionalSeatsTierMode()
+    {
+        $config = $this->getFullConfig();
+        $tier_mode = (bool) ($config['integrations']['additional_seats']['tier_mode'] ?? false);
+        $tier_skus = $this->getAdditionalSeatsTierSkus();
+        $default_active = $tier_mode || !empty($tier_skus);
+
+        return (bool) apply_filters('wicket/org-roster/additional_seats_tier_mode', $default_active);
+    }
+
+    /**
+     * Get the tier-to-SKU map for multi-tier additional seats.
+     *
+     * Keys are membership tier slugs (the 'memberships' resource slug), values are WooCommerce
+     * product SKUs. When empty the flow falls back to deriving a SKU per tier as
+     * '{additional_seats_sku}-{tier-slug}' via getAdditionalSeatsTierSkuForSlug().
+     *
+     * @return array<string,string> Map of tier slug => product SKU.
+     */
+    public function getAdditionalSeatsTierSkus()
+    {
+        $config = $this->getFullConfig();
+        $tier_skus = $config['integrations']['additional_seats']['tier_skus'] ?? [];
+        $tier_skus = is_array($tier_skus) ? $tier_skus : [];
+
+        // Normalize keys/values to trimmed strings.
+        $normalized = [];
+        foreach ($tier_skus as $tier_slug => $sku) {
+            $tier_slug = is_string($tier_slug) ? trim($tier_slug) : '';
+            $sku = is_string($sku) ? trim($sku) : '';
+            if ($tier_slug !== '' && $sku !== '') {
+                $normalized[$tier_slug] = $sku;
+            }
+        }
+
+        return apply_filters('wicket/org-roster/additional_seats_tier_skus', $normalized);
+    }
+
+    /**
+     * Get the query parameter / GF hidden field name used to carry the tier slug.
+     *
+     * Default 'tier-slug'.
+     *
+     * @return string
+     */
+    public function getAdditionalSeatsTierSlugField()
+    {
+        $config = $this->getFullConfig();
+        $field = $config['integrations']['additional_seats']['tier_slug_field'] ?? 'tier-slug';
+        $field = is_string($field) ? trim($field) : '';
+        if ($field === '') {
+            $field = 'tier-slug';
+        }
+
+        return apply_filters('wicket/org-roster/additional_seats_tier_slug_field', $field);
+    }
+
+    /**
+     * Resolve the WooCommerce product SKU for a given membership tier slug.
+     *
+     * Uses an explicit tier_skus mapping when present; otherwise derives the SKU as
+     * '{additional_seats_sku}-{tier-slug}' so a site only needs to create WooCommerce products
+     * following that convention.
+     *
+     * @param string $tier_slug Membership tier slug.
+     * @return string|null Resolved SKU, or null when the tier slug is empty.
+     */
+    public function getAdditionalSeatsTierSkuForSlug($tier_slug)
+    {
+        $tier_slug = is_string($tier_slug) ? trim($tier_slug) : '';
+        if ($tier_slug === '') {
+            return null;
+        }
+
+        $tier_skus = $this->getAdditionalSeatsTierSkus();
+        if (isset($tier_skus[$tier_slug]) && $tier_skus[$tier_slug] !== '') {
+            return $tier_skus[$tier_slug];
+        }
+
+        $prefix = $this->getAdditionalSeatsSku();
+        $prefix = is_string($prefix) ? trim($prefix) : '';
+        if ($prefix === '') {
+            $prefix = 'additional-seats';
+        }
+
+        return $prefix . '-' . $tier_slug;
+    }
+
+    /**
+     * Reverse-lookup: resolve the membership tier slug for a given WooCommerce product SKU.
+     *
+     * Used on order processing to classify a line item as a tier-specific seat product. Returns
+     * null when the SKU is not recognised as a tier seat product (either tier mode is off or the
+     * SKU does not map to a configured/derived tier).
+     *
+     * @param string $sku WooCommerce product SKU.
+     * @return string|null Tier slug, or null.
+     */
+    public function getAdditionalSeatsTierSlugForSku($sku)
+    {
+        $sku = is_string($sku) ? trim($sku) : '';
+        if ($sku === '') {
+            return null;
+        }
+
+        $tier_skus = $this->getAdditionalSeatsTierSkus();
+        foreach ($tier_skus as $tier_slug => $tier_sku) {
+            if ($tier_sku === $sku) {
+                return $tier_slug;
+            }
+        }
+
+        // Derived-SKU fallback ONLY when no explicit tier_skus map is configured. With an
+        // explicit map present (S1), any product whose SKU merely starts with the prefix would
+        // otherwise false-positive as a tier seat (e.g. a future 'additional-seats-bundle').
+        // Flag-only tier mode (empty map) is the only case that relies on derived SKUs.
+        if (!empty($tier_skus)) {
+            return null;
+        }
+
+        $prefix = $this->getAdditionalSeatsSku();
+        $prefix = is_string($prefix) ? trim($prefix) : '';
+        if ($prefix === '') {
+            $prefix = 'additional-seats';
+        }
+        $prefix_dash = $prefix . '-';
+        if (str_starts_with($sku, $prefix_dash)) {
+            $candidate = substr($sku, strlen($prefix_dash));
+            $candidate = is_string($candidate) ? trim($candidate) : '';
+            if ($candidate !== '') {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Get allowed document types.
      *
      * @return array Array of allowed document file types.

--- a/src/WicketORM/Services/MembershipService.php
+++ b/src/WicketORM/Services/MembershipService.php
@@ -444,6 +444,104 @@ class MembershipService
     }
 
     /**
+     * Resolve the membership tier slug for an organization membership.
+     *
+     * The tier slug is the slug of the related 'memberships' (tier) resource, retrieved via the
+     * organization_memberships include=membership payload. Used by the multi-tier additional
+     * seats flow to drive form conditional logic and per-tier WooCommerce product resolution.
+     *
+     * Resolution order:
+     *   1. 'included' membership whose id matches data.relationships.membership.data.id
+     *      (type 'memberships') -> attributes.slug.
+     *   2. First 'memberships' resource in 'included' -> attributes.slug (when the relationship
+     *      pointer is absent but a tier resource is present).
+     *   3. Direct attributes on the org membership (membership_tier_slug / slug) as a defensive
+     *      fallback if the API ever exposes the slug inline.
+     *
+     * Results are memoized per (org_uuid, membership_id) for the request.
+     *
+     * @param string $organization_uuid Organization UUID (contextual; used for cache keying).
+     * @param string $membership_id     Organization membership UUID.
+     * @return string Tier slug, or '' when it cannot be resolved.
+     */
+    public function getMembershipTierSlug(string $organization_uuid, string $membership_id): string
+    {
+        $membership_id = trim($membership_id);
+        if ($membership_id === '') {
+            return '';
+        }
+
+        static $cache = [];
+        $cache_key = $organization_uuid . '|' . $membership_id;
+        if (array_key_exists($cache_key, $cache)) {
+            return $cache[$cache_key];
+        }
+
+        $cache[$cache_key] = '';
+
+        $membership_data = $this->getOrgMembershipData($membership_id);
+        if (!is_array($membership_data)) {
+            return '';
+        }
+
+        $cache[$cache_key] = $this->extractTierSlugFromOrgMembership($membership_data);
+
+        return $cache[$cache_key];
+    }
+
+    /**
+     * Extract the tier slug from a single organization_memberships payload (with included).
+     *
+     * @param array $membership_data Organization membership payload.
+     * @return string
+     */
+    public function extractTierSlugFromOrgMembership(array $membership_data): string
+    {
+        $attrs = (array) ($membership_data['data']['attributes'] ?? []);
+
+        // Defensive inline fallbacks.
+        foreach (['membership_tier_slug', 'tier_slug', 'membership_slug'] as $key) {
+            $candidate = $attrs[$key] ?? null;
+            if (is_string($candidate) && trim($candidate) !== '') {
+                return trim($candidate);
+            }
+        }
+
+        $included = $membership_data['included'] ?? null;
+        if (!is_array($included)) {
+            return '';
+        }
+
+        $relationship_membership_id = $membership_data['data']['relationships']['membership']['data']['id'] ?? null;
+        $first_slug = '';
+
+        foreach ($included as $item) {
+            if (($item['type'] ?? '') !== 'memberships') {
+                continue;
+            }
+
+            $slug = $item['attributes']['slug'] ?? null;
+            if (!is_string($slug) || trim($slug) === '') {
+                continue;
+            }
+
+            $trimmed = trim($slug);
+            if ($first_slug === '') {
+                $first_slug = $trimmed;
+            }
+
+            if (
+                $relationship_membership_id !== null
+                && (string) ($item['id'] ?? '') === (string) $relationship_membership_id
+            ) {
+                return $trimmed;
+            }
+        }
+
+        return $first_slug;
+    }
+
+    /**
      * Resolve tier-mapped seat limit from config.
      *
      * @param array $membershipData Organization membership payload.

--- a/src/WicketORM/templates-partials/members-view-unified.php
+++ b/src/WicketORM/templates-partials/members-view-unified.php
@@ -198,8 +198,11 @@ include __DIR__ . '/members-list-unified.php';
 
     <?php if (!empty($setup_issues)) : ?>
     <div class="orgman-setup-warning wt_mt-4 wt_p-4 wt_rounded-md" style="background:#fff8e1;border:2px solid #f9a825;color:#5d4037;">
+        <h3 class="orgman-setup-warning__title wt_mt-0 wt_mb-2 wt_font-semibold wt_text-lg" style="display:flex;align-items:center;gap:0.4rem;">
+            <span aria-hidden="true">⚠️</span> <?php esc_html_e('Visible to administrators only', 'wicket-acc'); ?>
+        </h3>
         <p class="wt_font-semibold wt_mb-2">
-            ⚠️ <?php esc_html_e('Additional Seats: Setup Incomplete (visible to administrators only)', 'wicket-acc'); ?>
+            <?php esc_html_e('Additional Seats: Setup Incomplete.', 'wicket-acc'); ?>
         </p>
         <p class="wt_mb-2"><?php esc_html_e('The "Purchase Additional Seats" button is hidden because the following items are not yet configured:', 'wicket-acc'); ?></p>
         <ul style="list-style:disc;padding-left:1.25rem;margin:0 0 0.5rem;">
@@ -214,6 +217,27 @@ include __DIR__ . '/members-list-unified.php';
                 }
                 ?></li>
             <?php endforeach; ?>
+        </ul>
+        <?php
+        $orgman_cfg = $configService->getFullConfig();
+        $orgman_form_slug = $orgman_cfg['integrations']['additional_seats']['form_slug'] ?? 'additional-seats';
+        $orgman_form_slug = is_string($orgman_form_slug) ? trim($orgman_form_slug) : 'additional-seats';
+        $orgman_tier_field = $configService->getAdditionalSeatsTierSlugField();
+        $orgman_token_attrs = 'title="' . esc_attr__('Click to copy', 'wicket-acc') . '" style="cursor:pointer;background:#fff3cd;border:1px solid #f9a825;border-radius:3px;padding:1px 5px;font-family:monospace;font-size:0.9em;"';
+        ?>
+        <ul class="orgman-setup-warning__config" style="list-style:none;padding-left:0;margin:0.5rem 0 0;border-top:1px solid #f9a825;padding-top:0.5rem;opacity:0.85;">
+            <li style="margin-bottom:0.5rem;">
+                <strong><?php esc_html_e('Expected Gravity Form slug:', 'wicket-acc'); ?></strong>
+                <code class="orgman-copy-token" data-copy-value="<?php echo esc_attr($orgman_form_slug); ?>" <?php echo $orgman_token_attrs; // phpcs:ignore ?>><?php echo esc_html($orgman_form_slug); ?></code><br>
+                <em style="display:block;margin-top:0.25rem;"><?php esc_html_e('Map this slug to the additional-seats Gravity Form under Gravity Forms > Wicket Settings > Form Slug ID Mapping.', 'wicket-acc'); ?></em>
+            </li>
+            <?php if ($orgman_tier_field !== '') : ?>
+            <li style="margin-bottom:0;">
+                <strong><?php esc_html_e('Tier slug hidden-field parameter:', 'wicket-acc'); ?></strong>
+                <code class="orgman-copy-token" data-copy-value="<?php echo esc_attr($orgman_tier_field); ?>" <?php echo $orgman_token_attrs; // phpcs:ignore ?>><?php echo esc_html($orgman_tier_field); ?></code><br>
+                <em style="display:block;margin-top:0.25rem;"><?php esc_html_e('Name of the hidden field (Parameter Name) on the form that receives the membership tier slug from the URL. GF conditional logic reads it to show only that tier’s quantity input, and the submission handler reads it to pick the right tier-specific product.', 'wicket-acc'); ?></em>
+            </li>
+            <?php endif; ?>
         </ul>
     </div>
     <script>

--- a/src/WicketORM/templates-partials/organization-members.php
+++ b/src/WicketORM/templates-partials/organization-members.php
@@ -257,8 +257,11 @@ $members_list_endpoint = $membersListEndpoint;
 	    if (!empty($setup_issues)):
 	        ?>
 		<div class="orgman-setup-warning wt_mt-4 wt_p-4 wt_rounded-md" style="background:#fff8e1;border:2px solid #f9a825;color:#5d4037;">
+			<h3 class="orgman-setup-warning__title wt_mt-0 wt_mb-2 wt_font-semibold wt_text-lg" style="display:flex;align-items:center;gap:0.4rem;">
+				<span aria-hidden="true">⚠️</span> <?php esc_html_e('Visible to administrators only', 'wicket-acc'); ?>
+			</h3>
 			<p class="wt_font-semibold wt_mb-2">
-				⚠️ <?php esc_html_e('Additional Seats: Setup Incomplete (visible to administrators only)', 'wicket-acc'); ?>
+				<?php esc_html_e('Additional Seats: Setup Incomplete.', 'wicket-acc'); ?>
 			</p>
 			<p class="wt_mb-2"><?php esc_html_e('The "Purchase Additional Seats" button is hidden because the following items are not yet configured:', 'wicket-acc'); ?></p>
 			<ul style="list-style:disc;padding-left:1.25rem;margin:0 0 0.5rem;">
@@ -274,6 +277,27 @@ $members_list_endpoint = $membersListEndpoint;
 				    ?></li>
 				<?php endforeach; ?>
 			</ul>
+		<?php
+		$orgman_cfg = $configService->getFullConfig();
+		$orgman_form_slug = $orgman_cfg['integrations']['additional_seats']['form_slug'] ?? 'additional-seats';
+		$orgman_form_slug = is_string($orgman_form_slug) ? trim($orgman_form_slug) : 'additional-seats';
+		$orgman_tier_field = $configService->getAdditionalSeatsTierSlugField();
+		$orgman_token_attrs = 'title="' . esc_attr__('Click to copy', 'wicket-acc') . '" style="cursor:pointer;background:#fff3cd;border:1px solid #f9a825;border-radius:3px;padding:1px 5px;font-family:monospace;font-size:0.9em;"';
+		?>
+		<ul class="orgman-setup-warning__config" style="list-style:none;padding-left:0;margin:0.5rem 0 0;border-top:1px solid #f9a825;padding-top:0.5rem;opacity:0.85;">
+			<li style="margin-bottom:0.5rem;">
+				<strong><?php esc_html_e('Expected Gravity Form slug:', 'wicket-acc'); ?></strong>
+				<code class="orgman-copy-token" data-copy-value="<?php echo esc_attr($orgman_form_slug); ?>" <?php echo $orgman_token_attrs; // phpcs:ignore ?>><?php echo esc_html($orgman_form_slug); ?></code><br>
+				<em style="display:block;margin-top:0.25rem;"><?php esc_html_e('Map this slug to the additional-seats Gravity Form under Gravity Forms > Wicket Settings > Form Slug ID Mapping.', 'wicket-acc'); ?></em>
+			</li>
+			<?php if ($orgman_tier_field !== '') : ?>
+			<li style="margin-bottom:0;">
+				<strong><?php esc_html_e('Tier slug hidden-field parameter:', 'wicket-acc'); ?></strong>
+				<code class="orgman-copy-token" data-copy-value="<?php echo esc_attr($orgman_tier_field); ?>" <?php echo $orgman_token_attrs; // phpcs:ignore ?>><?php echo esc_html($orgman_tier_field); ?></code><br>
+				<em style="display:block;margin-top:0.25rem;"><?php esc_html_e('Name of the hidden field (Parameter Name) on the form that receives the membership tier slug from the URL. GF conditional logic reads it to show only that tier’s quantity input, and the submission handler reads it to pick the right tier-specific product.', 'wicket-acc'); ?></em>
+			</li>
+			<?php endif; ?>
+		</ul>
 		</div>
 		<script>
 		(function () {

--- a/src/WicketORM/templates-partials/supplemental-members.php
+++ b/src/WicketORM/templates-partials/supplemental-members.php
@@ -24,6 +24,21 @@ if (empty($membership_id) && isset($_GET['membership_uuid'])) {
     $membership_id = sanitize_text_field($_GET['membership_uuid']);
 }
 
+// Multi-tier: pass the membership tier slug through to the form so it can drive conditional
+// logic and resolve the correct tier-specific product on submission.
+$config_service = new \WicketORM\Services\ConfigService();
+$tier_slug_field = $config_service->getAdditionalSeatsTierSlugField();
+$tier_slug = '';
+foreach (array_unique(array_filter([$tier_slug_field, 'tier_slug', 'tier-slug'])) as $key) {
+    if (isset($_GET[$key])) {
+        $candidate = sanitize_text_field(wp_unslash($_GET[$key]));
+        if ($candidate !== '') {
+            $tier_slug = $candidate;
+            break;
+        }
+    }
+}
+
 // Helper function for back link (WPML-aware)
 if (!function_exists('WicketORM\Templates\get_my_account_page_url')) {
     function get_my_account_page_url($slug)
@@ -45,7 +60,7 @@ if (!function_exists('WicketORM\Templates\get_my_account_page_url')) {
         <?php
             // Render Gravity Forms form
             if (class_exists('GFForms')) {
-                echo \WicketORM\Helpers\GravityFormsHelper::get_form_html($org_uuid, $membership_id);
+                echo \WicketORM\Helpers\GravityFormsHelper::get_form_html($org_uuid, $membership_id, $tier_slug);
             } else {
                 ?>
         <div class="woocommerce-error">


### PR DESCRIPTION
## What

Adds an opt-in multi-tier additional seats flow to the account centre, so organizations that hold several active membership tiers at once (e.g. ESCRS) can purchase roster seats against the correct membership record for each tier. Legacy single-SKU sites are unaffected.

Ref: [WWID-1680](https://app.asana.com/1/1138832104141584/task/1213056646701864)

## Why

The existing "Purchase Additional Seats" feature assumes one product and one membership per org. ESCRS orgs can hold multiple active memberships for different tiers simultaneously (a National Society membership and a Trainee National Society membership, for example), so the purchase callout has to pass the membership ID and the membership tier slug to the form, and the form has to resolve the correct tier-specific WooCommerce product. On order completion the seat increase must land on the correct membership for the current year, per line item.

## How

- **Opt-in config.** Tier mode activates only when `additional_seats.tier_mode` is true or `additional_seats.tier_skus` is non-empty. When off, every code path behaves exactly as before. New `ConfigService` getters cover tier-mode gating, SKU derivation (`{prefix}-{tier-slug}` or explicit map), and reverse classification.
- **Tier resolution.** `MembershipService::getMembershipTierSlug()` reads the tier slug from the `memberships` resource (`attributes.slug`) via the org membership `relationships.membership` included data.
- **Form and cart.** `getPurchaseFormUrl()` appends `tier-slug`. The Gravity Forms helper recognizes a `tier-slug` hidden field and per-tier `seat_quantity_{slug}` number fields, resolves the tier-specific product on submission, and stamps `tier_slug` on the cart item.
- **Fulfilment is MDP-only per line item.** On order completion, `processTierSeatLineItems()` bumps the correct `organization_memberships.max_assignments` for each tier seat line item. The legacy WooCommerce Subscription + `wicket_membership` CPT block is skipped entirely for tier orders.
- **Truth source is line-item meta**, not the single user-meta record, because one user-meta record cannot represent several memberships.
- **Backwards compatibility holds.** Legacy single-SKU sites keep the hardcoded quantity cap of 100; tier-mode fields honour the configured `max_quantity`.

### Peer review fixes included

- Partial MDP failure no longer permanently drops unfulfilled tier items. The order-level `additional_seats_processed` guard is only set when every tier line item succeeds; partial fulfilment stamps `tier_seats_partial` so failed items stay retry-eligible on the next status hook. Per-item `tier_seats_applied` meta governs re-entry safety.
- `classifySeatProduct()` skips the derived-SKU reverse-lookup fallback when an explicit `tier_skus` map is present, preventing false positives like `additional-seats-bundle`.
- `getAdditionalSeatsTierProductIds()` is memoized per request.
- Flag-only tier mode (empty `tier_skus`) now surfaces a clear setup issue instead of failing silently.
- The setup-warning card shows the expected Gravity Form slug and the tier-slug field parameter with explanations for the implementation team.

## Testing

- [x] New Warden suite: `tests/Unit/Roster/Services/MultiTierAdditionalSeatsTest.php` (30 tests, 49 assertions). Full Roster Unit suite green: 245 tests, 846 assertions.
- [x] All touched files pass `php -l`.
- [ ] Manual QA on ESCRS staging pending: the four WooCommerce products (`additional-seats-{tier-slug}`) must exist and the `additional-seats` slug must be mapped to Gravity Form 22 in the Wicket GF slug mapping.

Closes WWID-1680
