### PR TITLE
Centralize roster removal into strategies; add forensic logging

### DIFF
--- a/src/WicketORM/Helpers/PermissionHelper.php
+++ b/src/WicketORM/Helpers/PermissionHelper.php
@@ -734,15 +734,108 @@ class PermissionHelper extends Helper
      * @param string $org_uuid    Organization UUID.
      * @return bool True if removal should be prevented.
      */
-    public static function is_contact_removal_prevented(string $person_uuid, string $org_uuid): bool
-    {
-        $organizationService = new \WicketORM\Services\OrganizationService();
+    public static function is_contact_removal_prevented(
+        string $person_uuid,
+        string $org_uuid,
+        ?\WicketORM\Services\OrganizationService $organizationService = null
+    ): bool {
+        $organizationService ??= new \WicketORM\Services\OrganizationService();
         $org_owner = $organizationService->getOrganizationOwner($org_uuid);
 
         if (is_wp_error($org_owner) || !$org_owner) {
             return false;
         }
 
-        return isset($org_owner->uuid) && (string) $org_owner->uuid === $person_uuid;
+        return self::extractOwnerUuid($org_owner) === $person_uuid;
+    }
+
+    /**
+     * Guard a member removal against owner-protection policy.
+     *
+     * Returns a WP_Error when removal must be refused because the target person is
+     * the organization owner and the policy blocks owner removal. Returns null when
+     * removal is allowed.
+     *
+     * The caller resolves the policy booleans from its own config path, because the
+     * default differs per roster mode: membership_cycle defaults to true, every
+     * other mode defaults to false. This helper intentionally does not read config,
+     * so each strategy/modal can apply its own default without a hidden override.
+     *
+     * Uses Shape A owner resolution (id-first, is_array/is_object dispatch) because
+     * the Wicket SDK entity exposes the resource id via the public $id property but
+     * not via a declared uuid property, and the SDK's fetch() can return a raw
+     * array on degenerate responses.
+     *
+     * @param string $org_id                        Organization ID.
+     * @param string $person_uuid                    UUID of the person being removed.
+     * @param bool   $prevent                        Resolved config: should owner removal be blocked?
+     * @param bool   $require_membership_owner_role  When true, owner must also hold the membership_owner role.
+     * @param \WicketORM\Services\OrganizationService|null $organizationService Inject to stub in tests.
+     * @param \WicketORM\Services\PermissionService|null   $permissionService   Inject to stub in tests.
+     * @return \WP_Error|null WP_Error when removal is forbidden, null when allowed.
+     */
+    public static function guardOwnerRemoval(
+        string $org_id,
+        string $person_uuid,
+        bool $prevent,
+        bool $require_membership_owner_role = false,
+        ?\WicketORM\Services\OrganizationService $organizationService = null,
+        ?\WicketORM\Services\PermissionService $permissionService = null
+    ): ?\WP_Error {
+        if (!$prevent || empty($org_id)) {
+            return null;
+        }
+
+        $organizationService ??= new \WicketORM\Services\OrganizationService();
+        $org_owner = $organizationService->getOrganizationOwner($org_id);
+        if (is_wp_error($org_owner) || !$org_owner) {
+            return null;
+        }
+
+        $owner_uuid = self::extractOwnerUuid($org_owner);
+        if ($owner_uuid === '' || $owner_uuid !== $person_uuid) {
+            return null;
+        }
+
+        if ($require_membership_owner_role) {
+            $permissionService ??= new \WicketORM\Services\PermissionService();
+            $current_roles = $permissionService->getPersonCurrentRolesByOrgId($person_uuid, $org_id);
+            if (!is_array($current_roles) || !in_array('membership_owner', $current_roles, true)) {
+                return null;
+            }
+        }
+
+        return new \WP_Error(
+            'owner_removal_forbidden',
+            __('The organization owner (Primary Member) cannot be removed.', 'wicket-acc')
+        );
+    }
+
+    /**
+     * Resolve the owner UUID from whatever shape getOrganizationOwner returns.
+     *
+     * Shape A dispatch: the SDK entity exposes $id (the JSON:API resource id, which
+     * is the UUID for people) reliably; uuid is not a declared property. The array
+     * branch covers the SDK's degenerate raw-array return on error responses.
+     *
+     * @param mixed $org_owner
+     * @return string
+     */
+    private static function extractOwnerUuid($org_owner): string
+    {
+        if (is_array($org_owner)) {
+            return (string) ($org_owner['id']
+                ?? ($org_owner['uuid']
+                ?? ($org_owner['data']['id']
+                ?? '')));
+        }
+
+        if (is_object($org_owner)) {
+            return (string) ($org_owner->id
+                ?? ($org_owner->uuid
+                ?? ''));
+        }
+
+        return '';
     }
 }

--- a/src/WicketORM/Services/ConnectionService.php
+++ b/src/WicketORM/Services/ConnectionService.php
@@ -593,12 +593,7 @@ class ConnectionService
             return $connections;
         }
 
-        $normalized_skip_types = array_values(array_unique(array_filter(array_map(static function ($type): string {
-            $normalized = strtolower(trim((string) $type));
-            $normalized = str_replace(['-', ' '], '_', $normalized);
-
-            return sanitize_key($normalized);
-        }, $skip_types))));
+        $normalized_skip_types = $this->normalizeSkipTypes($skip_types);
 
         $ended_ids = [];
         $skipped_ids = [];
@@ -671,6 +666,110 @@ class ConnectionService
             'count' => count($ended_ids),
             'connection_ids' => $ended_ids,
         ];
+    }
+
+    /**
+     * Continue-on-error counterpart to endActivePersonOrganizationConnections().
+     *
+     * Ends every active person-to-organization connection for a person, honoring
+     * the same protected-type skip list, but attempts every record regardless of
+     * per-record failure. Used by removal flows (modal/strategies) that must keep
+     * going when one connection cannot be ended, matching the modal's parity.
+     *
+     * The existing endActivePersonOrganizationConnections() stays fail-fast because
+     * the add-path stale-relationship repair depends on early abort semantics.
+     *
+     * @param string $person_uuid The UUID of the person.
+     * @param string $org_id      The organization ID.
+     * @param array  $skip_types  Relationship types to leave intact.
+     * @return array{ended: list<string>, errors: array<string,string>}
+     *   ended:  connection IDs that were successfully end-dated
+     *   errors: map of connection_id => error message (non-fatal)
+     */
+    public function endAllActivePersonOrganizationConnections($person_uuid, $org_id, array $skip_types = [])
+    {
+        $ended = [];
+        $errors = [];
+
+        $connections = $this->getActivePersonOrganizationConnections($person_uuid, $org_id);
+        if (is_wp_error($connections)) {
+            \Wicket()->log()->error('[OrgMan] endAllActivePersonOrganizationConnections aborted: active connection lookup error', [
+                'source' => 'wicket-orgman',
+                'person_uuid' => $person_uuid,
+                'org_id' => $org_id,
+                'error_code' => $connections->get_error_code(),
+                'error_message' => $connections->get_error_message(),
+            ]);
+
+            return ['ended' => $ended, 'errors' => $errors];
+        }
+
+        $normalized_skip_types = $this->normalizeSkipTypes($skip_types);
+
+        foreach ($connections as $connection) {
+            $connection_id = (string) ($connection['id'] ?? '');
+            if ($connection_id === '') {
+                continue;
+            }
+
+            $raw_relationship_type = (string) ($connection['attributes']['type'] ?? '');
+            $normalized_relationship_type = sanitize_key(str_replace(['-', ' '], '_', strtolower(trim($raw_relationship_type))));
+
+            // Leave protected relationship types intact.
+            if (!empty($skip_types)) {
+                if (
+                    in_array($raw_relationship_type, $skip_types, true)
+                    || in_array($normalized_relationship_type, $normalized_skip_types, true)
+                ) {
+                    continue;
+                }
+            }
+
+            $result = $this->endRelationshipToday($person_uuid, $connection_id, $org_id);
+            if (is_wp_error($result)) {
+                $errors[$connection_id] = $result->get_error_message();
+                \Wicket()->log()->error('[OrgMan] endAllActivePersonOrganizationConnections failed to end connection', [
+                    'source' => 'wicket-orgman',
+                    'connection_id' => $connection_id,
+                    'error_code' => $result->get_error_code(),
+                    'error_message' => $result->get_error_message(),
+                ]);
+
+                continue;
+            }
+
+            $ended[] = $connection_id;
+        }
+
+        \Wicket()->log()->info('[OrgMan] endAllActivePersonOrganizationConnections result', [
+            'source' => 'wicket-orgman',
+            'person_uuid' => $person_uuid,
+            'org_id' => $org_id,
+            'skip_types' => array_values($skip_types),
+            'ended_count' => count($ended),
+            'ended_ids' => $ended,
+            'error_count' => count($errors),
+            'errors' => $errors,
+        ]);
+
+        return ['ended' => $ended, 'errors' => $errors];
+    }
+
+    /**
+     * Normalize a list of relationship-type skip entries into unique sanitized slugs.
+     * Shared by both end-active-connections methods (fail-fast and continue-on-error).
+     *
+     * @param array $skip_types
+     * @return list<string>
+     */
+    private function normalizeSkipTypes(array $skip_types): array
+    {
+        return array_values(array_unique(array_filter(array_map(static function ($type): string {
+            $normalized = strtolower(trim((string) $type));
+            $normalized = str_replace(['-', ' '], '_', $normalized);
+
+            return sanitize_key($normalized);
+        }, $skip_types))));
     }
 
     /**

--- a/src/WicketORM/Services/MembershipRosterReader.php
+++ b/src/WicketORM/Services/MembershipRosterReader.php
@@ -273,6 +273,19 @@ class MembershipRosterReader
 
                 $normalized = $this->normalizeMembershipResponse($response);
                 if (null !== $normalized) {
+                    // Forensic log: correlates a fresh MDP fetch with prior removal logs.
+                    // Debug level keeps the hot read path quiet by default; retrievable when raised.
+                    $logger->debug('[OrgMan] Fresh member list fetch from MDP', [
+                        'source' => 'wicket-orgman',
+                        'membership_uuid' => $membershipUuid,
+                        'page' => $page,
+                        'size' => $size,
+                        'returned_count' => is_array($normalized['data'] ?? null) ? count($normalized['data']) : 0,
+                        'person_ids' => array_values(array_map(static function ($row): string {
+                            return (string) ($row['relationships']['person']['data']['id'] ?? $row['person']['id'] ?? '?');
+                        }, is_array($normalized['data'] ?? null) ? $normalized['data'] : [])),
+                    ]);
+
                     // Cache initial load only (no search term)
                     if (empty($searchTerm)) {
                         $isLazy = (bool) ($args['lazy'] ?? false);

--- a/src/WicketORM/Services/MembershipRosterWriter.php
+++ b/src/WicketORM/Services/MembershipRosterWriter.php
@@ -588,18 +588,44 @@ class MembershipRosterWriter
      */
     public function removeMember($org_id, $person_uuid, $context = [])
     {
+        $logger = \Wicket()->log();
+        $log_context = [
+            'source' => 'wicket-orgman',
+            'action' => 'remove_member',
+            'roster_mode' => (string) $this->configService->getRosterMode(),
+            'org_id' => $org_id,
+            'person_uuid' => $person_uuid,
+            'membership_uuid' => $context['membership_uuid'] ?? null,
+            'person_membership_id' => $context['person_membership_id'] ?? null,
+            'has_connection_id' => !empty($context['connection_id']),
+        ];
+
         if (!function_exists('wicket_api_client')) {
+            $logger->error('[OrgMan] removeMember aborted: wicket_api_client unavailable', $log_context);
+
             return new \WP_Error('api_unavailable', 'Wicket API client is not available.');
         }
+
+        $logger->info('[OrgMan] removeMember start', $log_context);
 
         $result = $this->getStrategy()->removeMember($org_id, $person_uuid, $context);
 
         // Invalidate read caches on success so the roster reflects the change immediately.
-        if (!is_wp_error($result) && is_array($result)) {
+        $cache_invalidated = false;
+        if (is_wp_error($result)) {
+            $logger->error('[OrgMan] removeMember failed', array_merge($log_context, [
+                'error_code' => $result->get_error_code(),
+                'error_message' => $result->get_error_message(),
+            ]));
+        } elseif (is_array($result)) {
             $membership_uuid = $context['membership_uuid'] ?? '';
             if ($membership_uuid !== '') {
                 $this->reader->clearMembersCache($membership_uuid);
+                $cache_invalidated = true;
             }
+            $logger->info('[OrgMan] removeMember success', array_merge($log_context, [
+                'cache_invalidated' => $cache_invalidated,
+            ]));
         }
 
         return $result;

--- a/src/WicketORM/Services/MembershipService.php
+++ b/src/WicketORM/Services/MembershipService.php
@@ -760,6 +760,13 @@ class MembershipService
                 return new \WP_Error('api_error', 'Failed to end-date person membership: ' . ($response['errors'][0]['detail'] ?? 'Unknown error'));
             }
 
+            \Wicket()->log()->info('[OrgMan] endPersonMembershipToday success', [
+                'source' => 'wicket-orgman',
+                'person_membership_id' => $person_membership_id,
+                'ends_at' => $ends_at,
+                'anchor' => $this->getRemovalAnchor(),
+            ]);
+
             return $response;
 
         } catch (\Exception $e) {
@@ -767,6 +774,105 @@ class MembershipService
 
             return new \WP_Error('end_person_membership_exception', $e->getMessage());
         }
+    }
+
+    /**
+     * End every active person_membership for a person within one org_membership.
+     *
+     * Queries the MDP for all person_memberships the person holds under the
+     * given organization membership and end-dates each active one via
+     * endPersonMembershipToday(). Continue-on-error: every record is attempted
+     * and per-record failures are collected, not fatal. Mirrors the authoritative
+     * loop that lived inline in the remove-member modal.
+     *
+     * @param string $person_uuid         The UUID of the person.
+     * @param string $org_membership_uuid The organization membership UUID.
+     * @return array{ended: list<string>, errors: array<string,string>}
+     *   ended:  person_membership IDs that were successfully end-dated
+     *   errors: map of person_membership_id => error message (non-fatal)
+     */
+    public function endAllActivePersonMembershipsForOrg($person_uuid, $org_membership_uuid)
+    {
+        $ended = [];
+        $errors = [];
+
+        if (empty($person_uuid) || empty($org_membership_uuid)) {
+            return ['ended' => $ended, 'errors' => $errors];
+        }
+
+        if (!function_exists('wicket_api_client')) {
+            \Wicket()->log()->error('MembershipService::endAllActivePersonMembershipsForOrg() - API client unavailable', ['source' => 'wicket-orgman']);
+
+            return ['ended' => $ended, 'errors' => $errors];
+        }
+
+        try {
+            $client = wicket_api_client();
+            $filter_data = [
+                'filter' => [
+                    'organization_membership_uuid_in' => [$org_membership_uuid],
+                    'person_id_eq' => $person_uuid,
+                ],
+            ];
+
+            $response = $client->post('/person_memberships/query', ['json' => $filter_data]);
+
+            if (is_wp_error($response)) {
+                \Wicket()->log()->error('MembershipService::endAllActivePersonMembershipsForOrg() - query failed', [
+                    'source' => 'wicket-orgman',
+                    'person_uuid' => $person_uuid,
+                    'org_membership_uuid' => $org_membership_uuid,
+                    'error' => $response->get_error_message(),
+                ]);
+
+                return ['ended' => $ended, 'errors' => $errors];
+            }
+
+            if (empty($response['data']) || !is_array($response['data'])) {
+                return ['ended' => $ended, 'errors' => $errors];
+            }
+
+            foreach ($response['data'] as $p_membership) {
+                $p_membership_id = $p_membership['id'] ?? null;
+                $p_membership_active = $p_membership['attributes']['active'] ?? false;
+
+                if (!$p_membership_id || !$p_membership_active) {
+                    continue;
+                }
+
+                $result = $this->endPersonMembershipToday($p_membership_id);
+                if (is_wp_error($result)) {
+                    $errors[(string) $p_membership_id] = $result->get_error_message();
+                    \Wicket()->log()->error('MembershipService::endAllActivePersonMembershipsForOrg() - failed to end membership', [
+                        'source' => 'wicket-orgman',
+                        'id' => $p_membership_id,
+                        'error' => $result->get_error_message(),
+                    ]);
+
+                    continue;
+                }
+
+                $ended[] = (string) $p_membership_id;
+            }
+        } catch (\Exception $e) {
+            \Wicket()->log()->error('MembershipService::endAllActivePersonMembershipsForOrg() - Exception: ' . $e->getMessage(), [
+                'source' => 'wicket-orgman',
+                'person_uuid' => $person_uuid,
+                'org_membership_uuid' => $org_membership_uuid,
+            ]);
+        }
+
+        \Wicket()->log()->info('[OrgMan] endAllActivePersonMembershipsForOrg result', [
+            'source' => 'wicket-orgman',
+            'person_uuid' => $person_uuid,
+            'org_membership_uuid' => $org_membership_uuid,
+            'ended_count' => count($ended),
+            'ended_ids' => $ended,
+            'error_count' => count($errors),
+            'errors' => $errors,
+        ]);
+
+        return ['ended' => $ended, 'errors' => $errors];
     }
 
     /**

--- a/src/WicketORM/Services/Strategies/CascadeStrategy.php
+++ b/src/WicketORM/Services/Strategies/CascadeStrategy.php
@@ -480,51 +480,58 @@ class CascadeStrategy implements RosterManagementStrategy
         ];
 
         try {
-            $person_membership_id = sanitize_text_field((string) ($context['person_membership_id'] ?? ''));
-
-            if ('' === $person_membership_id) {
-                return new \WP_Error('missing_person_membership_id', 'Person membership ID is required to remove a member.');
-            }
-
             $config = $this->configService()->getFullConfig();
             $access_permissions = is_array($config['access']['permissions'] ?? null) ? $config['access']['permissions'] : [];
             $prevent_owner_removal = (bool) ($access_permissions['prevent_owner_removal'] ?? false);
             $owner_must_have_membership_owner = (bool) ($access_permissions['owner_removal_requires_membership_owner_role'] ?? false);
 
-            if ($prevent_owner_removal && !empty($org_id)) {
-                $org_owner = $this->organizationService()->getOrganizationOwner($org_id);
-                $owner_uuid = '';
-                if (is_array($org_owner)) {
-                    $owner_uuid = $org_owner['id'] ?? ($org_owner['uuid'] ?? ($org_owner['data']['id'] ?? ''));
-                } elseif (is_object($org_owner)) {
-                    $owner_uuid = $org_owner->id ?? ($org_owner->uuid ?? '');
-                }
-
-                $is_org_owner = !is_wp_error($org_owner)
-                    && $org_owner
-                    && !empty($owner_uuid)
-                    && (string) $owner_uuid === (string) $person_uuid;
-
-                if ($is_org_owner) {
-                    $owner_role_match = true;
-                    if ($owner_must_have_membership_owner) {
-                        $current_roles = $this->permissionService()->getPersonCurrentRolesByOrgId($person_uuid, $org_id);
-                        $owner_role_match = is_array($current_roles) && in_array('membership_owner', $current_roles, true);
-                    }
-
-                    if ($owner_role_match) {
-                        return new \WP_Error('owner_removal_forbidden', 'The organization owner (Primary Member) cannot be removed.');
-                    }
-                }
+            $owner_guard = \WicketORM\Helpers\PermissionHelper::guardOwnerRemoval(
+                $org_id,
+                $person_uuid,
+                $prevent_owner_removal,
+                $owner_must_have_membership_owner,
+                $this->organizationService(),
+                $this->permissionService()
+            );
+            if (is_wp_error($owner_guard)) {
+                return $owner_guard;
             }
 
-            $remove_result = $this->membershipService()->endPersonMembershipToday($person_membership_id);
-            if (is_wp_error($remove_result)) {
-                $logger->error('[OrgMan] Cascade strategy failed to end person membership', array_merge($log_context, [
-                    'error' => $remove_result->get_error_message(),
-                ]));
+            $membership_uuid = sanitize_text_field((string) ($context['membership_uuid'] ?? ''));
 
-                return $remove_result;
+            if ('' === $membership_uuid) {
+                return new \WP_Error('missing_membership_uuid', 'Organization membership UUID is required to remove a member.');
+            }
+
+            // End every active person_membership this person holds under this org membership.
+            // Continue-on-error: a single record failure does not abort the rest.
+            $membership_result = $this->membershipService()->endAllActivePersonMembershipsForOrg($person_uuid, $membership_uuid);
+            if (!empty($membership_result['errors'])) {
+                $logger->warning('[OrgMan] Cascade strategy ended memberships with per-record errors', array_merge($log_context, [
+                    'ended_count' => count($membership_result['ended']),
+                    'error_count' => count($membership_result['errors']),
+                    'errors' => $membership_result['errors'],
+                ]));
+            } else {
+                $logger->debug('[OrgMan] Cascade strategy ended person memberships', array_merge($log_context, [
+                    'ended_count' => count($membership_result['ended']),
+                ]));
+            }
+
+            // End every active person-to-organization connection. Continue-on-error sibling;
+            // no removal-side skip-types config exists today, so pass an empty allowlist
+            // for exact parity with the current modal behavior.
+            $connection_result = $this->connectionService()->endAllActivePersonOrganizationConnections($person_uuid, $org_id, []);
+            if (!empty($connection_result['errors'])) {
+                $logger->warning('[OrgMan] Cascade strategy ended connections with per-record errors', array_merge($log_context, [
+                    'ended_count' => count($connection_result['ended']),
+                    'error_count' => count($connection_result['errors']),
+                    'errors' => $connection_result['errors'],
+                ]));
+            } else {
+                $logger->debug('[OrgMan] Cascade strategy ended person connections', array_merge($log_context, [
+                    'ended_count' => count($connection_result['ended']),
+                ]));
             }
 
             $roles_to_remove = $this->permissionService()->getPersonCurrentRolesByOrgId($person_uuid, $org_id);

--- a/src/WicketORM/Services/Strategies/DirectAssignmentStrategy.php
+++ b/src/WicketORM/Services/Strategies/DirectAssignmentStrategy.php
@@ -803,42 +803,24 @@ class DirectAssignmentStrategy implements RosterManagementStrategy
                 }
             }
 
-            $person_membership_id = $context['person_membership_id'] ?? null;
-
-            if (empty($person_membership_id)) {
-                return new WP_Error('missing_person_membership_id', 'Person membership ID is required to remove a member.');
-            }
+            // Direct mode ends connections and roles; it does not read person_membership_id.
+            // The value is intentionally not captured: connection-only removals are valid here.
 
             $config = $this->configService()->getFullConfig();
             $preserve_relationship = (bool) ($config['member_management']['removal']['direct']['preserve_relationship'] ?? false);
             $prevent_owner_removal = (bool) ($config['access']['permissions']['prevent_owner_removal'] ?? false);
             $owner_must_have_membership_owner = (bool) ($config['access']['permissions']['owner_removal_requires_membership_owner_role'] ?? false);
 
-            if ($prevent_owner_removal && !empty($org_id)) {
-                $org_owner = $this->organizationService()->getOrganizationOwner($org_id);
-                $owner_uuid = '';
-                if (is_array($org_owner)) {
-                    $owner_uuid = $org_owner['id'] ?? ($org_owner['uuid'] ?? ($org_owner['data']['id'] ?? ''));
-                } elseif (is_object($org_owner)) {
-                    $owner_uuid = $org_owner->id ?? ($org_owner->uuid ?? '');
-                }
-
-                $is_org_owner = !is_wp_error($org_owner)
-                    && $org_owner
-                    && !empty($owner_uuid)
-                    && (string) $owner_uuid === (string) $person_uuid;
-
-                if ($is_org_owner) {
-                    $owner_role_match = true;
-                    if ($owner_must_have_membership_owner) {
-                        $current_roles = $this->permissionService()->getPersonCurrentRolesByOrgId($person_uuid, $org_id);
-                        $owner_role_match = is_array($current_roles) && in_array('membership_owner', $current_roles, true);
-                    }
-
-                    if ($owner_role_match) {
-                        return new WP_Error('owner_removal_forbidden', 'The organization owner (Primary Member) cannot be removed.');
-                    }
-                }
+            $owner_guard = \WicketORM\Helpers\PermissionHelper::guardOwnerRemoval(
+                $org_id,
+                $person_uuid,
+                $prevent_owner_removal,
+                $owner_must_have_membership_owner,
+                $this->organizationService(),
+                $this->permissionService()
+            );
+            if (is_wp_error($owner_guard)) {
+                return $owner_guard;
             }
 
             if (!$preserve_relationship) {

--- a/src/WicketORM/Services/Strategies/GroupsStrategy.php
+++ b/src/WicketORM/Services/Strategies/GroupsStrategy.php
@@ -346,26 +346,18 @@ class GroupsStrategy implements RosterManagementStrategy
             $prevent_owner_removal = (bool) ($access_permissions['prevent_owner_removal'] ?? false);
             $owner_must_have_membership_owner = (bool) ($access_permissions['owner_removal_requires_membership_owner_role'] ?? false);
 
-            if ($prevent_owner_removal && !empty($org_uuid)) {
-                $org_owner = $this->organizationService()->getOrganizationOwner($org_uuid);
-                $is_org_owner = !is_wp_error($org_owner)
-                    && $org_owner
-                    && isset($org_owner->uuid)
-                    && (string) $org_owner->uuid === (string) $person_uuid;
+            $owner_guard = \WicketORM\Helpers\PermissionHelper::guardOwnerRemoval(
+                $org_uuid,
+                $person_uuid,
+                $prevent_owner_removal,
+                $owner_must_have_membership_owner,
+                $this->organizationService(),
+                $this->permissionService()
+            );
+            if (is_wp_error($owner_guard)) {
+                $logger->warning('Groups strategy attempted to remove organization owner', $log_context);
 
-                if ($is_org_owner) {
-                    $owner_role_match = true;
-                    if ($owner_must_have_membership_owner) {
-                        $current_roles = $this->permissionService()->getPersonCurrentRolesByOrgId($person_uuid, $org_uuid);
-                        $owner_role_match = is_array($current_roles) && in_array('membership_owner', $current_roles, true);
-                    }
-
-                    if ($owner_role_match) {
-                        $logger->warning('Groups strategy attempted to remove organization owner', $log_context);
-
-                        return new \WP_Error('owner_removal_forbidden', 'The organization owner (Primary Member) cannot be removed.');
-                    }
-                }
+                return $owner_guard;
             }
 
             $groups_config = is_array($orgman_config['groups'] ?? null) ? $orgman_config['groups'] : [];

--- a/src/WicketORM/Services/Strategies/MembershipCycleStrategy.php
+++ b/src/WicketORM/Services/Strategies/MembershipCycleStrategy.php
@@ -130,33 +130,22 @@ class MembershipCycleStrategy implements RosterManagementStrategy
         $access_permissions = is_array($config['access']['permissions'] ?? null) ? $config['access']['permissions'] : [];
         $prevent_owner_removal = (bool) ($cycle_config['prevent_owner_removal'] ?? true);
         $owner_must_have_membership_owner = (bool) ($access_permissions['owner_removal_requires_membership_owner_role'] ?? false);
-        if ($prevent_owner_removal && !empty($org_id)) {
-            $org_owner = $this->organizationService()->getOrganizationOwner($org_id);
-            $owner_uuid = '';
-            if (is_array($org_owner)) {
-                $owner_uuid = $org_owner['id'] ?? ($org_owner['uuid'] ?? ($org_owner['data']['id'] ?? ''));
-            } elseif (is_object($org_owner)) {
-                $owner_uuid = $org_owner->id ?? ($org_owner->uuid ?? '');
-            }
-
-            $is_org_owner = !is_wp_error($org_owner)
-                && $org_owner
-                && !empty($owner_uuid)
-                && (string) $owner_uuid === (string) $person_uuid;
-
-            if ($is_org_owner) {
-                $owner_role_match = true;
-                if ($owner_must_have_membership_owner) {
-                    $current_roles = $this->permissionService()->getPersonCurrentRolesByOrgId($person_uuid, $org_id);
-                    $owner_role_match = is_array($current_roles) && in_array('membership_owner', $current_roles, true);
-                }
-
-                if ($owner_role_match) {
-                    return new WP_Error('owner_removal_forbidden', 'The organization owner (Primary Member) cannot be removed.');
-                }
-            }
+        $owner_guard = \WicketORM\Helpers\PermissionHelper::guardOwnerRemoval(
+            $org_id,
+            $person_uuid,
+            $prevent_owner_removal,
+            $owner_must_have_membership_owner,
+            $this->organizationService(),
+            $this->permissionService()
+        );
+        if (is_wp_error($owner_guard)) {
+            return $owner_guard;
         }
 
+        // End the selected person_membership assignment for this cycle. Cycle mode targets a
+        // specific assignment identified by person_membership_id (see
+        // docs/ORM/engineering/strategy-membership-cycle/membership-cycle-add-remove.md); it does
+        // NOT broadly end every membership the person holds under the org membership.
         $remove_result = $this->membershipService()->endPersonMembershipToday($person_membership_id);
         if (is_wp_error($remove_result)) {
             return $remove_result;

--- a/src/WicketORM/templates-partials/process/remove-member.php
+++ b/src/WicketORM/templates-partials/process/remove-member.php
@@ -4,10 +4,15 @@
  * Hypermedia partial for Remove Member modal processing.
  *
  * Renders the form (GET) and processes submissions (POST).
+ *
+ * Removal business logic lives in MembershipRosterWriter::removeMember, which
+ * dispatches to the active roster strategy. This modal is intentionally thin:
+ * nonce + input sanitization, permission check, member-name resolution for the
+ * success message, SSE rendering, and list refresh.
  */
 
 use WicketORM\Services\ConfigService;
-use WicketORM\Services\ConnectionService;
+use WicketORM\Services\MemberService;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -36,7 +41,7 @@ if ('POST' === strtoupper($request_method)) {
     $person_connection_ids = isset($_POST['connection_id']) ? sanitize_text_field(wp_unslash($_POST['connection_id'])) : '';
     $person_membership_id = isset($_POST['person_membership_id']) ? sanitize_text_field(wp_unslash($_POST['person_membership_id'])) : '';
 
-    // Require org_uuid and person_uuid, but allow either connection_id OR person_membership_id
+    // Require org_uuid and person_uuid, but allow either connection_id OR person_membership_id.
     if (empty($org_uuid) || empty($person_uuid) || (empty($person_connection_ids) && empty($person_membership_id))) {
         status_header(200);
         WicketORM\Helpers\DatastarSSE::renderError(__('Organization UUID, person UUID, and connection IDs are required.', 'wicket-acc'), '#remove-member-messages', ['removeMemberSubmitting' => false, 'membersLoading' => false]);
@@ -52,14 +57,6 @@ if ('POST' === strtoupper($request_method)) {
         return;
     }
 
-    // Handle comma-separated connection IDs (like legacy system)
-    if (is_string($person_connection_ids) && strpos($person_connection_ids, ',') !== false) {
-        $connection_ids = explode(',', $person_connection_ids);
-    } else {
-        $connection_ids = [$person_connection_ids];
-    }
-    $connection_ids = array_filter(array_map('trim', $connection_ids));
-
     try {
         $configService = new ConfigService();
         $roster_mode = (string) $configService->getRosterMode();
@@ -68,11 +65,9 @@ if ('POST' === strtoupper($request_method)) {
         $member_view_config = is_array($presentation_config['member_view'] ?? null) ? $presentation_config['member_view'] : [];
         $remove_auto_close_on_success = (bool) ($member_view_config['add_member_auto_close_on_success'] ?? false);
         $remove_auto_close_delay_seconds = max(0, (int) ($member_view_config['add_member_auto_close_delay_seconds'] ?? 7));
-        $preserve_direct_relationship = (bool) ($orgman_config['member_management']['removal']['direct']['preserve_relationship'] ?? false);
-        $membershipService = new WicketORM\Services\MembershipService();
-        $permissionService = new WicketORM\Services\PermissionService();
-        $organizationService = new WicketORM\Services\OrganizationService();
 
+        // Cycle mode genuinely keys off a membership uuid; surface that as a clear
+        // pre-check before any removal work. The strategy enforces it too.
         if ($roster_mode === 'membership_cycle' && empty($membership_uuid)) {
             status_header(200);
             WicketORM\Helpers\DatastarSSE::renderError(
@@ -84,53 +79,13 @@ if ('POST' === strtoupper($request_method)) {
             return;
         }
 
-        $cycle_config = is_array($orgman_config['membership']['cycle'] ?? null)
-            ? $orgman_config['membership']['cycle']
-            : [];
-        $access_permissions = is_array($orgman_config['access']['permissions'] ?? null)
-            ? $orgman_config['access']['permissions']
-            : [];
-
-        $prevent_owner_removal = ($roster_mode === 'membership_cycle')
-            ? (bool) ($cycle_config['prevent_owner_removal'] ?? true)
-            : (bool) ($access_permissions['prevent_owner_removal'] ?? false);
-        $owner_must_have_membership_owner = (bool) ($access_permissions['owner_removal_requires_membership_owner_role'] ?? false);
-
-        if ($prevent_owner_removal) {
-            $org_owner = $organizationService->getOrganizationOwner($org_uuid);
-            $is_org_owner = !is_wp_error($org_owner)
-                && $org_owner
-                && isset($org_owner->uuid)
-                && (string) $org_owner->uuid === $person_uuid;
-
-            if ($is_org_owner) {
-                $owner_role_match = true;
-                if ($owner_must_have_membership_owner) {
-                    $current_roles = $permissionService->getPersonCurrentRolesByOrgId($person_uuid, $org_uuid);
-                    $owner_role_match = is_array($current_roles) && in_array('membership_owner', $current_roles, true);
-                }
-
-                if ($owner_role_match) {
-                    status_header(200);
-                    WicketORM\Helpers\DatastarSSE::renderError(
-                        __('The organization owner (Primary Member) cannot be removed.', 'wicket-acc'),
-                        '#remove-member-messages',
-                        ['removeMemberSubmitting' => false, 'membersLoading' => false]
-                    );
-
-                    return;
-                }
-            }
-        }
-
-        // Get person name for success message
+        // Resolve a friendly name for the success message.
         $member_name = 'Member';
         if (!empty($person_name)) {
             $member_name = $person_name;
         } elseif (function_exists('wicket_get_person_by_id')) {
             $person_data = wicket_get_person_by_id($person_uuid);
             if ($person_data) {
-                // Handle both array and object formats
                 $attributes = null;
                 if (is_array($person_data) && !empty($person_data['data']['attributes'])) {
                     $attributes = $person_data['data']['attributes'];
@@ -149,193 +104,34 @@ if ('POST' === strtoupper($request_method)) {
             }
         }
 
-        $removal_success = false;
-        $connection_service = new ConnectionService();
+        // Dispatch to the strategy layer. The writer resolves the active roster mode,
+        // invokes the strategy's removeMember, and invalidates the members cache.
+        $member_service = new MemberService($configService);
+        $context = [
+            'membership_uuid' => $membership_uuid,
+            'person_membership_id' => $person_membership_id,
+            'connection_id' => $person_connection_ids,
+            'person_email' => $person_email,
+        ];
 
-        // 1. End all person memberships for this person/email in this organization membership
-        if (!empty($membership_uuid) && !empty($person_uuid)) {
-            try {
-                $client = wicket_api_client();
-                $filter_data = [
-                    'filter' => [
-                        'organization_membership_uuid_in' => [$membership_uuid],
-                        'person_id_eq' => $person_uuid,
-                    ],
-                ];
+        $result = $member_service->removeMember($org_uuid, $person_uuid, $context);
 
-                $response = $client->post('/person_memberships/query', ['json' => $filter_data]);
-
-                if (!is_wp_error($response) && !empty($response['data'])) {
-                    foreach ($response['data'] as $p_membership) {
-                        $p_membership_id = $p_membership['id'] ?? null;
-                        $p_membership_active = $p_membership['attributes']['active'] ?? false;
-
-                        if ($p_membership_id && $p_membership_active) {
-                            $result = $membershipService->endPersonMembershipToday($p_membership_id);
-                            if (!is_wp_error($result)) {
-                                $removal_success = true;
-                            } else {
-                                \Wicket()->log()->error('Failed to end extra membership', [
-                                    'source' => 'wicket-orgman',
-                                    'id' => $p_membership_id,
-                                    'error' => $result->get_error_message(),
-                                ]);
-                            }
-                        }
-                    }
-                }
-            } catch (Throwable $e) {
-                \Wicket()->log()->error('Membership query exception', [
-                    'source' => 'wicket-orgman',
-                    'error' => $e->getMessage(),
-                ]);
-            }
-        }
-
-        // 2. Fallback or explicit removal of the provided person membership ID
-        if (!empty($person_membership_id)) {
-            $result = $membershipService->endPersonMembershipToday($person_membership_id);
-
-            if (is_wp_error($result)) {
-                \Wicket()->log()->error('Failed to end-date primary person membership', [
-                    'source' => 'wicket-orgman',
-                    'person_membership_id' => $person_membership_id,
-                    'error' => $result->get_error_message(),
-                ]);
-            } else {
-                $removal_success = true;
-            }
-        }
-
-        if ($roster_mode === 'membership_cycle') {
-            if (!$removal_success) {
-                status_header(200);
-                WicketORM\Helpers\DatastarSSE::renderError(
-                    __('Failed to remove member. Person membership ID is required.', 'wicket-acc'),
-                    '#remove-member-messages',
-                    ['removeMemberSubmitting' => false, 'membersLoading' => false]
-                );
-
-                return;
-            }
-
-            if (!empty($membership_uuid)) {
-                $orgman_instance = WicketORM\OrgMan::get_instance();
-                $orgman_instance->clearMembersCache($membership_uuid);
-            }
-
-            $success_message = sprintf(
-                esc_html__('Successfully removed %1$s from the organization.', 'wicket-acc'),
-                '<strong>' . esc_html($member_name) . '</strong>'
-            );
-            $element_patches = WicketORM\Helpers\MemberListRefresh::buildOrgMembersListPatches(
-                $org_uuid,
-                $membership_uuid,
-                $org_dom_suffix,
-                1,
-                ''
-            );
-
+        if (is_wp_error($result)) {
             status_header(200);
-            WicketORM\Helpers\DatastarSSE::renderSuccess($success_message, '#remove-member-messages', [
-                'removeMemberSubmitting' => false,
-                'removeMemberSuccess' => true,
-                'membersLoading' => false,
-                'autoCloseCountdown' => $remove_auto_close_on_success ? $remove_auto_close_delay_seconds : 0,
-            ], 0, 'remove-countdown', $element_patches);
+            WicketORM\Helpers\DatastarSSE::renderError(
+                $result->get_error_message(),
+                '#remove-member-messages',
+                ['removeMemberSubmitting' => false, 'membersLoading' => false]
+            );
 
             return;
         }
 
-        $should_end_relationships = $roster_mode !== 'direct' || !$preserve_direct_relationship;
-        $use_direct_action_time_relationship_end = $roster_mode === 'direct' && !$preserve_direct_relationship;
-
-        // 3. End ALL connections for this person to this organization
-        if (!empty($person_uuid) && $should_end_relationships) {
-            $connections = $connection_service->getPersonConnectionsById($person_uuid);
-            if (!empty($connections['data'])) {
-                foreach ($connections['data'] as $conn) {
-                    $conn_org_id = $conn['relationships']['organization']['data']['id'] ?? null;
-                    $conn_id = $conn['id'] ?? null;
-                    $conn_active = $conn['attributes']['active'] ?? false;
-
-                    if ($conn_org_id === $org_uuid && $conn_id && $conn_active) {
-                        $result = $use_direct_action_time_relationship_end
-                            ? $connection_service->endRelationshipAtActionTime($person_uuid, $conn_id, $org_uuid)
-                            : $connection_service->endRelationshipToday($person_uuid, $conn_id, $org_uuid);
-                        if (!is_wp_error($result)) {
-                            $removal_success = true;
-                        } else {
-                            \Wicket()->log()->error('Failed to end extra connection', [
-                                'source' => 'wicket-orgman',
-                                'id' => $conn_id,
-                                'error' => $result->get_error_message(),
-                            ]);
-                        }
-                    }
-                }
-            }
-        }
-
-        // 4. Fallback or explicit removal of the provided connection IDs
-        if (!empty($connection_ids) && $should_end_relationships) {
-            foreach ($connection_ids as $connection_id) {
-                if (empty($connection_id)) {
-                    continue;
-                }
-                $result = $use_direct_action_time_relationship_end
-                    ? $connection_service->endRelationshipAtActionTime($person_uuid, $connection_id, $org_uuid)
-                    : $connection_service->endRelationshipToday($person_uuid, $connection_id, $org_uuid);
-
-                if (is_wp_error($result)) {
-                    \Wicket()->log()->error('Failed to end primary relationship', [
-                        'source' => 'wicket-orgman',
-                        'person_uuid' => $person_uuid,
-                        'connection_id' => $connection_id,
-                        'org_uuid' => $org_uuid,
-                        'error' => $result->get_error_message(),
-                    ]);
-                } else {
-                    $removal_success = true;
-                }
-            }
-        }
-
-        // 2. Remove all org-scoped roles
-        $roles_to_remove = $permissionService->getPersonCurrentRolesByOrgId($person_uuid, $org_uuid);
-        if (!empty($roles_to_remove)) {
-            $role_removal_result = $permissionService->removePersonRolesFromOrg($person_uuid, $roles_to_remove, $org_uuid);
-
-            if (is_wp_error($role_removal_result)) {
-                \Wicket()->log()->error('Failed to remove roles', [
-                    'source' => 'wicket-orgman',
-                    'person_uuid' => $person_uuid,
-                    'org_uuid' => $org_uuid,
-                    'roles' => $roles_to_remove,
-                    'error' => $role_removal_result->get_error_message(),
-                ]);
-            }
-        }
-
-        // If still no success, throw an error
-        if (!$removal_success) {
-            status_header(200);
-            WicketORM\Helpers\DatastarSSE::renderError(__('Failed to remove member. Person membership ID is required.', 'wicket-acc'), '#remove-member-messages', ['removeMemberSubmitting' => false, 'membersLoading' => false]);
-
-            return;
-        }
-
-        // Success message
         $success_message = sprintf(
             esc_html__('Successfully removed %1$s from the organization.', 'wicket-acc'),
             '<strong>' . esc_html($member_name) . '</strong>'
         );
 
-        // Clear members cache for this organization after successful removal
-        if ($removal_success && !empty($membership_uuid)) {
-            $orgman_instance = WicketORM\OrgMan::get_instance();
-            $orgman_instance->clearMembersCache($membership_uuid);
-        }
         $element_patches = WicketORM\Helpers\MemberListRefresh::buildOrgMembersListPatches(
             $org_uuid,
             $membership_uuid,

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,8 +1,8 @@
 <?php return array(
     'root' => array(
         'name' => 'industrialdev/wicket-wp-account-centre',
-        'pretty_version' => '1.7.4',
-        'version' => '1.7.4.0',
+        'pretty_version' => '1.7.5',
+        'version' => '1.7.5.0',
         'reference' => null,
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
@@ -148,8 +148,8 @@
             'dev_requirement' => false,
         ),
         'industrialdev/wicket-wp-account-centre' => array(
-            'pretty_version' => '1.7.4',
-            'version' => '1.7.4.0',
+            'pretty_version' => '1.7.5',
+            'version' => '1.7.5.0',
             'reference' => null,
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',


### PR DESCRIPTION
## What

Centralizes organization roster member removal into the strategy layer and adds forensic logging to diagnose the "member reappears after removal" issue reported by NJBIA.

## Why this matters (the bug, in plain terms)

NJBIA reported that when an org manager removes a member from their roster, the member disappears from the screen, but reappears a few minutes later. In the Wicket MDP (the central database) the member correctly shows as end-dated. So the removal *looked* like it worked, but something was putting the person back.

When we investigated, we found the real story was more uncomfortable than a single bug. This PR addresses the parts we could fix confidently, and adds logging to close the loop on the parts that still need a live reproduction.

## What we found (three separate problems)

We split the work into three streams because they are genuinely different problems, even though they all touch the same screen.

### 1. Removal logic was duplicated five times with drift (FIXED)

The system supports four "strategies" for how an org manages its roster (cascade, direct, groups, membership_cycle). The removal button in the UI is a single modal file that, historically, did all the removal work itself in one big block of code, instead of handing off to the strategy that matches the site's configured mode.

This meant the same logic (end the memberships, end the connections, strip the roles, check the owner, clear the cache) was written five times: once in the modal, once per strategy. And those copies had drifted apart. The modal was the most complete. The cascade strategy, for example, only ended a single membership record and never ended the person's connections. Nothing actually called the strategy path for removal.

That duplication is a landmine. The next person to change removal behavior would have to remember to change five places, and if they forgot one, that mode would silently behave differently.

This PR makes the modal a thin layer: it validates the request, checks permissions, asks the strategy to do the removal, and renders the result. All business logic now lives in the strategy layer, reached through one dispatcher (`MembershipRosterWriter::removeMember`). We extracted the shared pieces (end-all-memberships, end-all-connections, owner-guard) into reusable service methods so every strategy uses the same implementation.

One important nuance we caught during review: the `membership_cycle` strategy has a documented contract to end only the *specific* membership the user selected, not every membership the person holds. An earlier draft of this work made cycle behave like cascade (end everything). We reverted that to honor the documented per-cycle contract. Different modes have intentionally different semantics.

This dirft on member removals is likely the problem that bring this issue to light in NJBIA.

### 2. The reported "reappear" symptom is now logged

The two suspects issues (from 1) both seems to live outside this code: either something is re-creating the membership record after we end it (for example, a WooCommerce subscription that still thinks the departed employee is active), or the central database considers an end-date of "today" as still-active for the rest of the calendar day. We cannot tell which without observing a live removal.

So this PR adds correlated logging across the removal and roster-read paths. When the issue recurs, we can read the logs and see exactly what happened.

## How the logging works

All the new logs share the tag `source = wicket-orgman` and carry the identifiers support can grep by: `org_id`, `person_uuid`, `membership_uuid`.

The flow a debugger reconstructs from the logs:

1. **Removal starts.** The dispatcher logs who is being removed, in which mode, with which IDs.
2. **What got ended.** Each primitive logs how many membership and connection records it ended, with their IDs, and any per-record errors.
3. **Cache cleared.** The dispatcher logs that the read cache was busted.
4. **Fresh roster fetch.** When the roster screen reloads and pulls a fresh list from the central database (a cache miss), the reader logs the count and the list of person IDs it got back.

If a removed member reappears, that person's ID will show up in step 4's list *after* step 1 logged their removal. That single observation tells us the record came back from the central database, which points the investigation at re-creation (suspect A) or date semantics (suspect B), without needing to reproduce the issue live.

The roster-fetch log is written at debug level, because the roster is read constantly. It stays quiet unless someone raises the log level during an investigation. The removal logs are at info level because they are infrequent and high-value.

## What this PR deliberately does not do

- It does not claim to fix the NJBIA reappear issue. That requires the logs plus a live reproduction.
- It does not change the documented per-cycle removal contract (membership_cycle still ends only the selected assignment).
- It does not swap how the direct strategy ends connections (it uses a fuller API write path than the other modes, and that is intentional).
- It does not add a configuration flag for the new touchpoint-on-removal behavior. Touchpoints already fire on every member *add*; firing them on every *remove* brings parity and is the correct audit trail.

## Testing

- PHP lint and php-cs-fixer pass on the full plugin.
- New and updated Pest unit tests in the wicket-warden (qa) repo cover: the owner-guard fix across all strategies, the end-all-memberships and end-all-connections primitives (including partial failures), the cycle targeted-end contract, the direct connection-only removal path, and the modal dispatch.
- A known pre-existing test-isolation flake in `MembershipServiceTest` (unrelated to this change, a Brain Monkey alias leak between two tests that both predate this work) is tracked separately.
