### PR TITLE
fix: roster member removal failing on first click for stacked roles

### DIFF
--- a/src/WicketORM/Services/PermissionService.php
+++ b/src/WicketORM/Services/PermissionService.php
@@ -222,6 +222,7 @@ class PermissionService
         $protected_roles = ['super_admin', 'administrator', 'user'];
 
         try {
+            $failed_roles = [];
             foreach ($roles as $role) {
                 // Skip protected roles
                 if (in_array($role, $protected_roles, true)) {
@@ -230,8 +231,17 @@ class PermissionService
 
                 $result = $this->removePersonSingleRoleFromOrg($person_uuid, $role, $org_id);
                 if (!$result) {
-                    return new \WP_Error('role_removal_failed', sprintf('Failed removing role %s.', $role));
+                    // Continue-on-error: collect failures and keep stripping the
+                    // remaining roles. A single bad role must not strand the rest.
+                    $failed_roles[] = $role;
                 }
+            }
+
+            if (!empty($failed_roles)) {
+                return new \WP_Error('role_removal_failed', sprintf(
+                    'Failed removing role(s): %s.',
+                    implode(', ', $failed_roles)
+                ));
             }
 
             return true;

--- a/src/WicketORM/Services/Strategies/CascadeStrategy.php
+++ b/src/WicketORM/Services/Strategies/CascadeStrategy.php
@@ -535,6 +535,14 @@ class CascadeStrategy implements RosterManagementStrategy
             }
 
             $roles_to_remove = $this->permissionService()->getPersonCurrentRolesByOrgId($person_uuid, $org_id);
+
+            // Exclude the base member role: it is tied to the membership that was
+            // just ended above, so the MDP revokes it server-side. Attempting to
+            // explicitly delete it fails (it is already gone from the person
+            // fetch by the time we get here) and would abort the whole removal.
+            $base_member_role = $config['member_management']['addition']['base_member_role'] ?? 'member';
+            $roles_to_remove = array_values(array_diff($roles_to_remove, [$base_member_role]));
+
             if (!empty($roles_to_remove)) {
                 $roles_result = $this->permissionService()->removePersonRolesFromOrg($person_uuid, $roles_to_remove, $org_id);
                 if (is_wp_error($roles_result)) {


### PR DESCRIPTION
## What

Stops roster member removal from failing on the first click when the member holds the base `member` role stacked with additional org roles (org_editor, membership_manager).

## Why

NJBIA reported removal failed on the first click and succeeded on the second. Root cause: the base `member` role is membership-linked. The MDP revokes it server-side when the membership ends. Cascade ends the membership first, then reads the role list back from an endpoint that lags roughly two seconds, so it still lists `member`. The removal loop tries to delete it through a path that already reflects the revocation, fails to find it, and the short-circuit aborted the entire removal, stranding the remaining org roles (`org_editor`, `membership_manager`). The second click worked because the lag cleared.

This was only visible on accounts stacking the base role with extras. Members carrying only the base role had nothing extra to strand, so the symptom stayed hidden.

## How

Two changes, defense in depth:

1. **CascadeStrategy::removeMember** excludes `base_member_role` (config `member_management.addition.base_member_role`, default `'member'`) from `roles_to_remove`. The membership-end step above already revokes it server-side, so explicit deletion is both redundant and the failure trigger.

2. **PermissionService::removePersonRolesFromOrg** now continues past a single failing role and collects per-role failures into an aggregate error, instead of short-circuiting on the first. Mirrors the continue-on-error pattern already used by `endAllActivePersonMembershipsForOrg`. One bad role no longer strands the rest.

## Testing

- PHP lint passes on both files.
- Verified in NJBIA staging: member removal now completes on the first click for accounts holding stacked roles (org_editor + member + membership_manager). Previously required two clicks, with the first leaving org_editor and membership_manager stranded.

## Risk notes

- The base-role exclusion reads from existing config with a `'member'` default. If a site configures a non-standard `base_member_role`, that slug is excluded instead. No behavior change for sites already using the default.
- Continue-on-error means a removal that partially fails now returns a `WP_Error` listing all failed roles at the end, rather than only the first. Callers that switch on the error message string should account for the new plural form, though no current caller does.

Depends on industrialdev/wicket-wp-base-plugin#12 for the companion fix to `wicket_remove_role` (org-scoping + idempotency).

Asana: [NJBIA] Roster Not Deleting Members (WWID-1665).
