### PR TITLE
fix: roster removal first-click failure and add member button styling #patch

### DIFF
--- a/src/WicketORM/Services/PermissionService.php
+++ b/src/WicketORM/Services/PermissionService.php
@@ -222,6 +222,7 @@ class PermissionService
         $protected_roles = ['super_admin', 'administrator', 'user'];
 
         try {
+            $failed_roles = [];
             foreach ($roles as $role) {
                 // Skip protected roles
                 if (in_array($role, $protected_roles, true)) {
@@ -230,8 +231,17 @@ class PermissionService
 
                 $result = $this->removePersonSingleRoleFromOrg($person_uuid, $role, $org_id);
                 if (!$result) {
-                    return new \WP_Error('role_removal_failed', sprintf('Failed removing role %s.', $role));
+                    // Continue-on-error: collect failures and keep stripping the
+                    // remaining roles. A single bad role must not strand the rest.
+                    $failed_roles[] = $role;
                 }
+            }
+
+            if (!empty($failed_roles)) {
+                return new \WP_Error('role_removal_failed', sprintf(
+                    'Failed removing role(s): %s.',
+                    implode(', ', $failed_roles)
+                ));
             }
 
             return true;

--- a/src/WicketORM/Services/Strategies/CascadeStrategy.php
+++ b/src/WicketORM/Services/Strategies/CascadeStrategy.php
@@ -535,6 +535,14 @@ class CascadeStrategy implements RosterManagementStrategy
             }
 
             $roles_to_remove = $this->permissionService()->getPersonCurrentRolesByOrgId($person_uuid, $org_id);
+
+            // Exclude the base member role: it is tied to the membership that was
+            // just ended above, so the MDP revokes it server-side. Attempting to
+            // explicitly delete it fails (it is already gone from the person
+            // fetch by the time we get here) and would abort the whole removal.
+            $base_member_role = $config['member_management']['addition']['base_member_role'] ?? 'member';
+            $roles_to_remove = array_values(array_diff($roles_to_remove, [$base_member_role]));
+
             if (!empty($roles_to_remove)) {
                 $roles_result = $this->permissionService()->removePersonRolesFromOrg($person_uuid, $roles_to_remove, $org_id);
                 if (is_wp_error($roles_result)) {

--- a/src/WicketORM/templates-partials/members-list-unified.php
+++ b/src/WicketORM/templates-partials/members-list-unified.php
@@ -491,30 +491,14 @@ $show_remove_policy_callout = (
     <?php if ($show_add_member_button) : ?>
         <div class="wt_mt-6">
             <?php if ($has_seats_available) : ?>
-                <?php
-                get_component('button', [
-                    'variant' => 'primary',
-                    'label' => __('Add Member', 'wicket-acc'),
-                    'type' => 'button',
-                    'classes' => ['add-member-button', 'wt_w-full', 'wt_py_2', 'wt_justify-center'],
-                    'atts' => [
-                        'data-on:click' => '$addMemberSuccess = false; $addMemberSubmitting = false; $addMemberSuccessMessage = \'\'; (() => { const modal = document.getElementById(\'membersAddModal\'); if (!modal) return; const form = modal.querySelector(\'form\'); if (form) form.reset(); const messages = modal.querySelector(`[id^=\'add-member-messages-\']`); if (messages) messages.innerHTML = \'\'; const groupMessages = modal.querySelector(\'#group-member-add-messages\'); if (groupMessages) groupMessages.innerHTML = \'\'; })(); $addMemberModalOpen = true',
-                    ],
-                ]);
-                ?>
+                <button type="button"
+                    class="button button--primary add-member-button wt_w-full wt_py-2 component-button"
+                    data-on:click="$addMemberSuccess = false; $addMemberSubmitting = false; $addMemberSuccessMessage = ''; (() => { const modal = document.getElementById('membersAddModal'); const form = modal ? modal.querySelector('form') : document.querySelector('#membersAddModal form'); if (form && form.reset) form.reset(); const messages = document.querySelector('[id^=\'add-member-messages-\']'); if (messages) messages.innerHTML = ''; })(); $addMemberModalOpen = true"><?php esc_html_e('Add Member', 'wicket-acc'); ?></button>
                 <?php if ($mode !== 'groups' && $show_bulk_upload) : ?>
                     <div class="wt_mt-3">
-                        <?php
-                        get_component('button', [
-                            'variant' => 'primary',
-                            'label' => __('Bulk Upload Members', 'wicket-acc'),
-                            'type' => 'button',
-                            'classes' => ['add-member-button', 'wt_w-full', 'wt_py_2', 'wt_justify-center'],
-                            'atts' => [
-                                'data-on:click' => '$bulkUploadModalOpen = true',
-                            ],
-                        ]);
-                    ?>
+                        <button type="button"
+                            class="button button--primary add-member-button wt_w-full wt_py-2 component-button"
+                            data-on:click="$bulkUploadModalOpen = true"><?php esc_html_e('Bulk Upload Members', 'wicket-acc'); ?></button>
                     </div>
                 <?php endif; ?>
             <?php endif; ?>


### PR DESCRIPTION
## What

Fixes two NJBIA roster issues in one PR: member removal failing on the first click for accounts with stacked roles, and the Add Member / Bulk Upload buttons rendering unstyled on initial page load.

## Why

**Roster removal.** NJBIA reported removal failed on the first click and succeeded on the second. Root cause: the base `member` role is membership-linked. The MDP revokes it server-side when the membership ends. Cascade ends the membership first, then reads the role list back from an endpoint that lags roughly two seconds, so it still lists `member`. The removal loop tries to delete it through a path that already reflects the revocation, fails to find it, and the short-circuit aborted the entire removal, stranding the remaining org roles (`org_editor`, `membership_manager`). The second click worked because the lag cleared. Only visible on accounts stacking the base role with extras; single-role members had nothing to strand.

**Button styling.** The roster screen renders from two templates: `members-list-unified.php` on initial page load and `members-list.php` on every Datastar refresh. The unified template rendered buttons via `get_component('button')`, which on a non-Wicket theme wraps each in a `<div class="wicket-base-plugin">` and was passed the `wt_py_2` class (underscore typo, no matching CSS rule). The canonical template uses plain `<button>`. Buttons looked broken on first load and only looked right after any roster operation triggered a refresh.

## How

**Roster removal (defense in depth):**
1. `CascadeStrategy::removeMember` excludes `base_member_role` (config `member_management.addition.base_member_role`, default `'member'`) from `roles_to_remove`. The membership-end step above already revokes it server-side.
2. `PermissionService::removePersonRolesFromOrg` continues past a single failing role and collects per-role failures into an aggregate error, instead of short-circuiting on the first. Mirrors `endAllActivePersonMembershipsForOrg`.

**Button styling:** the two `get_component('button')` calls (Add Member + Bulk Upload) are replaced with plain `<button>` markup matching `members-list.php` exactly: `wt_py-2` (hyphen, valid), no wrapper div, click handler aligned to canonical. Initial load and refresh now emit byte-identical button HTML.

## Testing

- PHP lint passes on all three files.
- Verified in NJBIA staging: member removal completes on the first click for accounts holding stacked roles (org_editor + member + membership_manager). Previously required two clicks.
- Verified in NJBIA staging: Add Member and Bulk Upload buttons render correctly on first page load, matching the post-refresh appearance.

## Risk notes

- The base-role exclusion reads from existing config with a `'member'` default. If a site configures a non-standard `base_member_role`, that slug is excluded instead. No behavior change for sites using the default.
- Continue-on-error means a removal that partially fails now returns a `WP_Error` listing all failed roles, rather than only the first. No current caller switches on the error message string.
- Button change is styling only. `members-list-groups.php` audited and already correct. Pagination buttons in the same file still use `get_component('button')` with the `wt_py_2` typo; same bug class, separate element, not touched here.

Depends on industrialdev/wicket-wp-base-plugin#12 for the companion fix to `wicket_remove_role` (org-scoping + idempotency + logged catch).

Asana: [NJBIA] Roster Not Deleting Members (WWID-1665).
