### PR TITLE
fix(roster): show delayed membership roster and correct summary block #patch

### DIFF
--- a/src/WicketORM/Services/MembershipRosterReader.php
+++ b/src/WicketORM/Services/MembershipRosterReader.php
@@ -71,6 +71,23 @@ class MembershipRosterReader
     }
 
     /**
+     * Resolve the active_at filter value for a membership-scoped roster query.
+     *
+     * Delegates to MembershipService, which owns the cached org-membership data.
+     * When the MDP reports the membership status as 'Delayed', the membership
+     * starts in the future and its assignments need active_at pointed at the
+     * membership's own start to appear (WWID-1910). Otherwise 'now' preserves
+     * active-only filtering (and the hiding of end-dated removed members).
+     *
+     * @param string $membershipUuid Organization membership UUID.
+     * @return string 'now', or the membership's starts_at when it is Delayed.
+     */
+    private function resolveActiveAt(string $membershipUuid): string
+    {
+        return $this->membershipService()->resolveActiveAt($membershipUuid);
+    }
+
+    /**
      * Lazily instantiate ConnectionService.
      *
      * @return ConnectionService
@@ -159,9 +176,15 @@ class MembershipRosterReader
         $logger = \Wicket()->log();
         $gen = $this->cacheService()->getMembershipGeneration($membershipUuid);
 
+        // WWID-1910: Delayed (future-starting) memberships need the roster window
+        // pointed at the membership's own start; otherwise active_at=now hides
+        // their future assignments. 'now' for everything else preserves current
+        // behavior (active-only, hiding end-dated removed members).
+        $activeAt = $this->resolveActiveAt($membershipUuid);
+
         // Cache initial load only (no search term)
         if (empty($searchTerm)) {
-            $cache_key = 'orgman_members_' . md5($membershipUuid . $page . $size . (int) $isLazy . $gen);
+            $cache_key = 'orgman_members_' . md5($membershipUuid . $page . $size . (int) $isLazy . $gen . $activeAt);
             $cached_data = $this->getCachedData($cache_key);
 
             if (false !== $cached_data) {
@@ -170,7 +193,7 @@ class MembershipRosterReader
         }
 
         if ('' !== $searchTerm) {
-            $search_cache_key = 'orgman_search_' . md5($membershipUuid . $searchTerm . $page . $size . $gen);
+            $search_cache_key = 'orgman_search_' . md5($membershipUuid . $searchTerm . $page . $size . $gen . $activeAt);
             $cached_search = $this->getCachedData($search_cache_key);
             if (false !== $cached_search) {
                 return $cached_search;
@@ -212,7 +235,7 @@ class MembershipRosterReader
         }
 
         if ('' !== $searchTerm && function_exists('wicket_api_client')) {
-            $search_cache_key ??= 'orgman_search_' . md5($membershipUuid . $searchTerm . $page . $size . $gen);
+            $search_cache_key ??= 'orgman_search_' . md5($membershipUuid . $searchTerm . $page . $size . $gen . $activeAt);
             $search_ttl ??= \WicketORM\Helpers\ConfigHelper::get_search_cache_duration();
 
             $queryArgs = [
@@ -225,7 +248,7 @@ class MembershipRosterReader
                 'filter' => [
                     'organization_membership_uuid_in'                    => [$membershipUuid],
                     'person_full_name_or_person_emails_address_cont'     => $searchTerm,
-                    'active_at'                                          => 'now',
+                    'active_at'                                          => $activeAt,
                 ],
             ];
 
@@ -258,7 +281,7 @@ class MembershipRosterReader
             'page[number]' => $page,
             'page[size]'   => $size,
             'include'      => 'person,membership',
-            'filter[active_at]' => 'now',
+            'filter[active_at]' => $activeAt,
         ];
 
         if ('' !== $searchTerm) {
@@ -290,7 +313,7 @@ class MembershipRosterReader
                     if (empty($searchTerm)) {
                         $isLazy = (bool) ($args['lazy'] ?? false);
                         $gen = $this->cacheService()->getMembershipGeneration($membershipUuid);
-                        $cache_key = 'orgman_members_' . md5($membershipUuid . $page . $size . (int) $isLazy . $gen);
+                        $cache_key = 'orgman_members_' . md5($membershipUuid . $page . $size . (int) $isLazy . $gen . $activeAt);
                         $this->setCachedData($cache_key, $normalized);
                     }
 
@@ -314,7 +337,7 @@ class MembershipRosterReader
                 $fallbackResponse = $client->get($endpoint . '?' . http_build_query([
                     'page[number]' => 1,
                     'page[size]' => max(100, $size),
-                    'filter[active_at]' => 'now',
+                    'filter[active_at]' => $activeAt,
                     'include' => 'person,emails,phones',
                 ]));
 
@@ -357,7 +380,7 @@ class MembershipRosterReader
         if (empty($searchTerm) && null !== $final_response) {
             $isLazy = (bool) ($args['lazy'] ?? false);
             $gen = $this->cacheService()->getMembershipGeneration($membershipUuid);
-            $cache_key = 'orgman_members_' . md5($membershipUuid . $page . $size . (int) $isLazy . $gen);
+            $cache_key = 'orgman_members_' . md5($membershipUuid . $page . $size . (int) $isLazy . $gen . $activeAt);
             $this->setCachedData($cache_key, $final_response);
         }
 
@@ -807,13 +830,15 @@ class MembershipRosterReader
         try {
             $client = wicket_api_client();
 
+            $activeAt = $this->resolveActiveAt($membershipUuid);
+
             // Use the same nested endpoint pattern as getMembershipMembers()
             // GET /organization_memberships/{membershipUuid}/person_memberships
             $endpoint = '/organization_memberships/' . rawurlencode($membershipUuid) . '/person_memberships';
             $queryParams = [
                 'page[number]' => 1,
                 'page[size]'   => 100,
-                'filter[active_at]' => 'now',
+                'filter[active_at]' => $activeAt,
                 'include'      => 'person,membership',
             ];
 

--- a/src/WicketORM/Services/MembershipService.php
+++ b/src/WicketORM/Services/MembershipService.php
@@ -592,6 +592,33 @@ class MembershipService
      * @param string $organization_uuid The organization UUID.
      * @return string|WP_Error The membership UUID or WP_Error on failure.
      */
+    /**
+     * Resolve the active_at filter value for a membership-scoped roster query.
+     *
+     * The MDP computes an authoritative membership status; when it is 'Delayed'
+     * the membership starts in the future and its assignments need active_at
+     * pointed at the membership's own start to appear (WWID-1910). Otherwise
+     * 'now' preserves active-only filtering. MembershipRosterReader delegates
+     * here.
+     *
+     * @param string $membership_uuid Organization membership UUID.
+     * @return string 'now', or the membership's starts_at when it is Delayed.
+     */
+    public function resolveActiveAt(string $membership_uuid): string
+    {
+        $data = $this->getOrgMembershipData($membership_uuid);
+        $status = $data['data']['attributes']['status'] ?? null;
+
+        if ($status === 'Delayed') {
+            $startsAt = $data['data']['attributes']['starts_at'] ?? null;
+            if ($startsAt) {
+                return (string) $startsAt;
+            }
+        }
+
+        return 'now';
+    }
+
     public function getCurrentPersonMembershipsByOrganization($organization_uuid)
     {
         if (empty($organization_uuid)) {
@@ -651,7 +678,7 @@ class MembershipService
                 'filter' => [
                     'organization_membership_uuid_in' => [$membership_uuid],
                     'person_full_name_or_person_emails_address_cont' => $query,
-                    'active_at' => 'now',
+                    'active_at' => $this->resolveActiveAt($membership_uuid),
                 ],
             ];
 
@@ -697,7 +724,7 @@ class MembershipService
             $size = absint($args['size'] ?? 15);
 
             $client = wicket_api_client();
-            $response = $client->get('/organization_memberships/' . rawurlencode($membership_uuid) . '/person_memberships?page[number]=' . $page . '&page[size]=' . $size . '&filter[active_at]=now');
+            $response = $client->get('/organization_memberships/' . rawurlencode($membership_uuid) . '/person_memberships?page[number]=' . $page . '&page[size]=' . $size . '&filter[active_at]=' . rawurlencode($this->resolveActiveAt($membership_uuid)));
 
             return isset($response['data']) ? $response : new \WP_Error('no_results', 'No membership members found.');
 

--- a/src/WicketORM/templates-partials/organization-details.php
+++ b/src/WicketORM/templates-partials/organization-details.php
@@ -72,7 +72,13 @@ $renewal_date = '';
 $seats_label = '';
 
 if ($roster_mode !== 'groups') {
-    $membership_uuid = $org_uuid ? $membershipService->getMembershipForOrganization($org_uuid) : '';
+    // Honor the membership UUID requested in the URL (e.g. a delayed/future renewal
+    // the user navigated to) before falling back to the org's active membership,
+    // so the summary block matches the membership actually being viewed (WWID-1910).
+    $requested_membership_uuid = isset($_GET['membership_uuid']) ? sanitize_text_field((string) wp_unslash($_GET['membership_uuid'])) : '';
+    $membership_uuid = $requested_membership_uuid !== ''
+        ? $requested_membership_uuid
+        : ($org_uuid ? $membershipService->getMembershipForOrganization($org_uuid) : '');
     $membership_data = $membership_uuid ? $membershipService->getOrgMembershipData($membership_uuid) : null;
 
     if ($membership_data) {


### PR DESCRIPTION
## What

Fixes two bugs on delayed (future-starting) organization memberships in `roster_mode='membership_cycle'`:

1. The "Manage Members" roster rendered empty for a delayed renewal, even though the MDP had assignments for it.
2. The membership summary block showed tier/dates/seats from the org's active membership instead of the delayed one being viewed.

## Why

A delayed membership starts in the future. When the MDP copies active assignments forward to that renewal (WWID-1906 carry-over), the cloned `person_memberships` inherit the target membership's future `starts_at`. Every roster read path in this plugin hardcoded `active_at=now`, and the MDP's `active_at` scope is an inclusive tsrange containment check (`tsrange(starts_at, …, '[]') @> now`) — so future-starting assignments fell outside the window and were filtered out.

On the summary side, `organization-details.php` ignored the `membership_uuid` in the URL and re-resolved the org's active membership, so the card always described the active cycle regardless of which renewal the user opened.

Asana: https://app.asana.com/1/1138832104141584/task/1215941056513784?focus=true

## How

**Bug 1 — roster window (status-driven).** The MDP serializes an authoritative `status` on every organization membership (`Active` / `Delayed` / `Inactive`), computed server-side from its own date window. Added `MembershipService::resolveActiveAt($membershipUuid)` which returns the membership's `starts_at` when `status === 'Delayed'`, and `'now'` otherwise. That value is threaded into all six read sites:
- `MembershipRosterReader.php`: search POST, main GET, search-fallback GET, SSE lazy-load `getMemberByPersonUuid`
- `MembershipService.php`: `membershipSearchMembers`, `getOrgMembershipMembers`

The reader delegates to the service so the logic lives in one place. Cache keys now include the resolved `$activeAt` so a delayed membership's roster and an active one's cache distinctly, and refresh correctly when status flips from Delayed to Active.

**Why status-driven over blanket removal:** removing `active_at` globally was considered and rejected. Member removal via `endPersonMembershipToday` end-dates but does not soft-delete, so `active_at=now` is currently the only thing hiding previously-removed members in active/cascade/direct rosters. Blanket removal would surface those on every client. This approach preserves `'now'` for all non-Delayed memberships, so active/cascade/direct behavior is unchanged; only Delayed memberships get the widened window.

**Bug 2 — summary block.** `organization-details.php` now honors `$_GET['membership_uuid']` (sanitized identically to `organization-members.php:39`) before falling back to `getMembershipForOrganization()`.

## How this was validated

- Verified against MDP Rails source: `active_at` is a ransack scope accepting any ISO timestamp; the nested route scopes by parent membership before the filter; the reference admin-React UI fetches rosters with empty filters.
- Cross-reviewed by Claude Opus (read-only) against the actual branch, which caught a cache key read/write mismatch that would have silently disabled the roster cache on every request — fixed before push.
- PHP lint clean on all three files; `php-cs-fixer --dry-run` reports 0 fixes needed.
- Hot-synced to ESCRS staging and confirmed working against the sample org in the Asana task: delayed roster now populates, summary block matches the delayed renewal.

## Testing

- [x] Delayed membership roster populates with its MDP assignments.
- [x] Summary block (tier, dates, seats) matches the viewed delayed membership.
- [x] Active/cascade/direct rosters unchanged (removed members still hidden).

