### PR TITLE
fix(roster): stop assigning default "Main Contact" on add member [WWI…

### DIFF
--- a/docs/bugfix/2026-07-16-add-member-default-relationship-type.md
+++ b/docs/bugfix/2026-07-16-add-member-default-relationship-type.md
@@ -1,0 +1,57 @@
+# Add Member: stop assigning a default "Main Contact" relationship
+
+**Date:** 2026-07-16
+**Ticket:** WWID-1988
+**Component:** `src/WicketORM/` (org roster, migrated into wicket-wp-account-centre)
+**Strategy affected:** direct assignment (also reached via `membership_cycle`, which delegates to it)
+**Asana:** https://app.asana.com/1/1138832104141584/project/1214714078970424/task/1216608950386698?focus=true
+
+## Symptom
+Adding a member through the Add Member form assigned the person the "Main Contact"
+person-to-organization relationship, even though no relationship type was selected.
+
+## Root cause
+The Add Member form's relationship-type field is disabled by default, so the form
+submits no `relationship_type`. `DirectAssignmentStrategy::addMember()` then fell back
+to the config default `relationships.addition.type`, which shipped as the literal
+slug `position`. `position` is not a valid person-organization relationship slug in
+Wicket, so the MDP resolved the connection to the tenant's default org relationship —
+surfacing as "Main Contact" on this tenant. (An empty/blank type defaults the same way,
+so the library must send *no* relationship at all, not just a blank one.)
+
+## Fix
+- `src/WicketORM/Config/OrgManConfig.php` — `relationships.addition.type` default changed
+  from `position` to `''` (kept as a filterable knob for tenants that want a valid
+  implicit default).
+- `src/WicketORM/Services/Strategies/DirectAssignmentStrategy.php` — only create the
+  `person_to_organization` connection when a relationship type was actually resolved;
+  otherwise skip it. The membership seat is the member's org linkage.
+- `src/WicketORM/Services/ConnectionService.php` — `buildConnectionPayload()` no longer
+  requires `type`; it omits the attribute when empty instead of erroring
+  (defense-in-depth; cascade/groups always pass a non-empty type).
+
+## Verified (staging MDP, real `addMember` path)
+Verified end-to-end against the staging MDP on the equivalent code in the standalone
+`wicket-lib-org-roster` (line-for-line identical to this `src/WicketORM/` copy):
+
+| | `addition.type` | connections created | roster relationship |
+|---|---|---|---|
+| Before | `position` | 1 × `main_contact` | "Main Contact" |
+| After | `` (empty) | 0 | none |
+
+Seat-only members still render correctly in the roster with no relationship label.
+A genuinely valid slug (e.g. `president`) is preserved by the MDP; only blank/invalid
+input gets defaulted.
+
+The add-member flow and the relationship-based contacts roster are complementary. The
+contacts roster (`ContactService`, `process/add-contact.php`) is the intended path for
+assigning person-to-organization relationships and requires an explicit
+`relationship_type`; it creates connections via `ConnectionService::ensurePersonConnection()`
+and never routes through `buildConnectionPayload()`, so this fix is isolated from it.
+`ConfigService::getFullConfig()` delegates to `OrgManConfig::get()`, so the
+`addition.type = ''` default flows through the standardized config accessor unchanged.
+
+## Out of scope
+`GroupsStrategy` and `CascadeStrategy` still fall back to
+`RelationshipHelper::get_default_relationship_type()` (`relationships.defaults.type`,
+shipped as `Position`) and would exhibit the same defaulting if used.

--- a/src/WicketORM/Config/OrgManConfig.php
+++ b/src/WicketORM/Config/OrgManConfig.php
@@ -125,7 +125,10 @@ final class OrgManConfig
                 ],
                 'removal' => [],
                 'addition' => [
-                    'type' => 'position',
+                    // Default relationship type applied when the add-member form does not
+                    // supply one. Empty by default so the library never sends a fabricated
+                    // slug; tenants that want an implicit default can set a valid slug here.
+                    'type' => '',
                 ],
                 'filters' => [
                     'allowlist' => [],

--- a/src/WicketORM/Services/ConnectionService.php
+++ b/src/WicketORM/Services/ConnectionService.php
@@ -230,8 +230,8 @@ class ConnectionService
      */
     public function buildConnectionPayload($person_id = null, $org_id = null, $connection_type = null, $type = null, $description = null)
     {
-        if (empty($person_id) || empty($org_id) || empty($connection_type) || empty($type)) {
-            return new WP_Error('invalid_params', 'Person ID, organization ID, connection type, and type are required.');
+        if (empty($person_id) || empty($org_id) || empty($connection_type)) {
+            return new WP_Error('invalid_params', 'Person ID, organization ID, and connection type are required.');
         }
 
         try {
@@ -243,7 +243,6 @@ class ConnectionService
                     'type'          => 'connections',
                     'attributes'    => [
                         'connection_type' => $connection_type,
-                        'type'            => $type,
                         'starts_at'       => $now_date,
                     ],
                     'relationships' => [
@@ -274,6 +273,14 @@ class ConnectionService
                     ],
                 ],
             ];
+
+            // Only send an explicit relationship type when one was resolved. Sending a
+            // blank/unrecognized slug makes the MDP fall back to its own default org
+            // relationship anyway, so we omit the attribute entirely rather than
+            // fabricating a value the tenant did not choose.
+            if (is_string($type) && $type !== '') {
+                $payload['data']['attributes']['type'] = $type;
+            }
 
             if ($description !== '') {
                 $payload['data']['attributes']['description'] = $description;

--- a/src/WicketORM/Services/Strategies/DirectAssignmentStrategy.php
+++ b/src/WicketORM/Services/Strategies/DirectAssignmentStrategy.php
@@ -94,10 +94,15 @@ class DirectAssignmentStrategy implements RosterManagementStrategy
             $base_member_role = $config['member_management']['addition']['base_member_role'] ?? 'member';
             $auto_assign_roles = $config['member_management']['addition']['auto_assign_roles'] ?? [];
 
-            // Use relationship type from context if provided, otherwise use config default
+            // Use relationship type from context if provided, otherwise fall back to
+            // the configured addition default. When neither is set (e.g. the add-member
+            // form's relationship-type field is disabled), leave it empty and send no
+            // type at all rather than fabricating an unrecognized slug — the MDP will
+            // then apply the tenant's own default relationship instead of rejecting a
+            // bogus value.
             $relationship_type = !empty($context['relationship_type'])
                 ? $context['relationship_type']
-                : ($config['relationships']['addition']['type'] ?? 'position');
+                : ($config['relationships']['addition']['type'] ?? '');
             $relationship_description = $context['relationship_description'] ?? $member_data['relationship_description'] ?? '';
             $relationship_description = is_string($relationship_description) ? sanitize_textarea_field($relationship_description) : '';
 
@@ -129,7 +134,16 @@ class DirectAssignmentStrategy implements RosterManagementStrategy
                     return $has_relationship;
                 }
 
-                if (!$has_relationship) {
+                // Only create a person-to-organization relationship when one was
+                // actually chosen/configured. With no resolved type the MDP would
+                // simply stamp its own default org relationship (surfacing as
+                // "Main Contact" on this tenant), assigning a contact role the
+                // membership manager never selected. Members added without a
+                // relationship type are plain members: the membership seat below is
+                // their org linkage, and they render correctly with no relationship
+                // label. A relationship description alone (no type) has nowhere to
+                // live, so it is intentionally skipped in that case too.
+                if (!$has_relationship && $relationship_type !== '') {
                     $connection_payload = $this->connectionService()->buildConnectionPayload(
                         $person_uuid,
                         $org_id,
@@ -146,6 +160,8 @@ class DirectAssignmentStrategy implements RosterManagementStrategy
                             $response_connection->get_error_message() ?? 'Failed to add employee connection'
                         );
                     }
+                } elseif (!$has_relationship) {
+                    $logger->debug('No relationship type resolved; skipping person-to-organization connection', $log_context);
                 }
 
                 // Assign person to membership seat to give them active membership


### PR DESCRIPTION
…D-1988]

When the Add Member form's relationship-type field is disabled (the default), the form submits no relationship_type. DirectAssignmentStrategy fell back to the config default relationships.addition.type = 'position', an invalid slug that the MDP resolves to the tenant default org relationship (surfacing as "Main Contact"). Blank resolves the same way, so the library must send no relationship at all.

- OrgManConfig: relationships.addition.type default '' (was 'position')
- DirectAssignmentStrategy: only create the person_to_organization connection when a relationship type was actually resolved; otherwise skip it and rely on the membership seat as the org linkage
- ConnectionService::buildConnectionPayload: no longer requires type; omits the attribute when empty instead of erroring (defense-in-depth)

Verified end-to-end against staging MDP on the identical wicket-lib-org-roster code: field-disabled add now creates 0 connections and the member renders with no relationship label; a valid slug is still preserved.