### PR TITLE
feat: add MDP Widget Config support to profile blocks

### DIFF
--- a/assets/js/wicket-acc-acf-field-deprecation.js
+++ b/assets/js/wicket-acc-acf-field-deprecation.js
@@ -29,13 +29,12 @@
  * `includes/blocks/ac-org-profile/init.php`). This script is pure editor-UX
  * sugar on top of that already-existing precedence rule.
  *
- * Special case: `mdp_json_sections` on the Org Profile block is dead weight —
- * the org profile widget component has no `sections` arg, so this field never
- * did anything even before `mdp_json_config` existed. It's excluded from the
- * migrate-link/auto-hide behavior above (see isInertOrgSectionsField()): no
- * migrate link (nothing meaningful to migrate), and it's never auto-hidden,
- * so a value saved here before this was noticed stays visible rather than
- * disappearing silently.
+ * Note: `mdp_json_sections` on the Org Profile block is currently inert — the
+ * org profile widget component has no `sections` arg, so a value migrated
+ * into `mdp_json_config`'s `sections` key has no effect on render today. The
+ * migrate link is still offered so a previously-saved value isn't stranded:
+ * if the org widget ever grows section support, migrated values are already
+ * in the right place under `mdp_json_config`.
  */
 (function($) {
   if (typeof acf === 'undefined') {
@@ -156,26 +155,7 @@
     }
   }
 
-  // mdp_json_sections is only wired up (has a working component arg to feed)
-  // on the Individual Profile block. On the Org Profile block it's a dead
-  // field the org profile widget component has never supported — kept only so
-  // a previously-saved value stays visible to whoever configured the block,
-  // not so it can be usefully migrated. Detect which block we're in via a
-  // sibling field unique to the org block's ACF group.
-  function isInertOrgSectionsField(legacyField, legacyName) {
-    return legacyName === 'mdp_json_sections' && !!findSiblingField(legacyField, 'hide_alternate_name_field');
-  }
-
   function handleLegacyField(legacyField, legacyName) {
-    if (isInertOrgSectionsField(legacyField, legacyName)) {
-      // No migrate link (there is nothing meaningful to migrate into config —
-      // the widget ignores this value either way) and never auto-hide, even
-      // when empty — this field's only job now is staying visible so a
-      // previously-saved value is never hidden from the person configuring
-      // the block.
-      return;
-    }
-
     ensureMigrateLink(legacyField, legacyName, LEGACY_WRAP_KEYS[legacyName]);
     // Covers the post-save/reload case: once the legacy value was purged and
     // saved, the field loads empty on the next page load and should stay hidden.

--- a/assets/js/wicket-acc-acf-field-deprecation.js
+++ b/assets/js/wicket-acc-acf-field-deprecation.js
@@ -15,11 +15,12 @@
  * should use `mdp_json_config` only.
  *
  * This script exists purely to make that migration painless for editors who
- * already have legacy values saved: it injects a "Copy this value into MDP
- * Widget Config" link under each legacy field. Clicking it JSON-parses the
- * legacy value, wraps it under the right key (`fields` or `sections`) into
- * whatever's already in `mdp_json_config`, writes the result back, and clears
- * the legacy field. It also hides each legacy field once its value is empty,
+ * already have legacy values saved: it injects a `Replace "fields"/"sections"
+ * in MDP Widget Config` link under each legacy field. Clicking it JSON-parses
+ * the legacy value and writes it under the right key (`fields` or `sections`)
+ * into whatever's already in `mdp_json_config`, replacing any existing value
+ * under that key wholesale (not merging it), then clears the legacy field.
+ * It also hides each legacy field once its value is empty,
  * so old blocks that never used them (or have already been migrated) don't
  * show dead, empty settings to editors.
  *
@@ -73,7 +74,7 @@
     // DOM ACF replaced) would otherwise pass an existence check while having
     // no working click handler on the currently-visible element.
     $input.find('.wicket-acc-mdp-migrate-link').remove();
-    var $link = jQuery('<p style="margin-top: 4px;"><a href="#" class="wicket-acc-mdp-migrate-link">Copy this value into MDP Widget Config &rarr;</a></p>');
+    var $link = jQuery('<p style="margin-top: 4px;"><a href="#" class="wicket-acc-mdp-migrate-link">Replace "' + wrapKey + '" in MDP Widget Config &rarr;</a></p>');
     $input.append($link);
 
     $link.find('a').on('click', function(e) {

--- a/assets/js/wicket-acc-acf-field-deprecation.js
+++ b/assets/js/wicket-acc-acf-field-deprecation.js
@@ -1,0 +1,193 @@
+/**
+ * TEMPORARY MIGRATION SCAFFOLDING — legacy MDP field migration for the AC
+ * Individual/Org Profile blocks. Safe to delete, file and all, once no block
+ * anywhere has a populated legacy `mdp_json_fields`/`mdp_json_sections` value
+ * left to migrate. Nothing else in either block depends on this file — see
+ * `includes/blocks/ac-individual-profile/init.php` and
+ * `includes/blocks/ac-org-profile/init.php`, which already fall back to the
+ * legacy fields correctly with zero help from this script.
+ *
+ * The `mdp_json_fields` / `mdp_json_sections` ACF fields predate the newer
+ * open-ended `mdp_json_config` field (see the widget-config refactor plan).
+ * They still work — a caller with only the legacy fields populated renders
+ * exactly as before — but they're deprecated: `mdp_json_config` supersedes
+ * them and, once set, they're ignored entirely (not merged). New editors
+ * should use `mdp_json_config` only.
+ *
+ * This script exists purely to make that migration painless for editors who
+ * already have legacy values saved: it injects a "Copy this value into MDP
+ * Widget Config" link under each legacy field. Clicking it JSON-parses the
+ * legacy value, wraps it under the right key (`fields` or `sections`) into
+ * whatever's already in `mdp_json_config`, writes the result back, and clears
+ * the legacy field. It also hides each legacy field once its value is empty,
+ * so old blocks that never used them (or have already been migrated) don't
+ * show dead, empty settings to editors.
+ *
+ * None of this is enforced server-side — a block with both legacy and config
+ * values populated will still render via `mdp_json_config` only (see
+ * `includes/blocks/ac-individual-profile/init.php` and
+ * `includes/blocks/ac-org-profile/init.php`). This script is pure editor-UX
+ * sugar on top of that already-existing precedence rule.
+ *
+ * Special case: `mdp_json_sections` on the Org Profile block is dead weight —
+ * the org profile widget component has no `sections` arg, so this field never
+ * did anything even before `mdp_json_config` existed. It's excluded from the
+ * migrate-link/auto-hide behavior above (see isInertOrgSectionsField()): no
+ * migrate link (nothing meaningful to migrate), and it's never auto-hidden,
+ * so a value saved here before this was noticed stays visible rather than
+ * disappearing silently.
+ */
+(function($) {
+  if (typeof acf === 'undefined') {
+    return;
+  }
+
+  // Legacy field name -> wrapper key in the MDP Widget Config JSON object.
+  var LEGACY_WRAP_KEYS = {
+    mdp_json_fields: 'fields',
+    mdp_json_sections: 'sections',
+  };
+
+  function findSiblingField(field, name) {
+    if (!field || !field.$el) {
+      return null;
+    }
+    var $wrapper = field.$el.closest('.acf-fields');
+    if (!$wrapper.length) {
+      return null;
+    }
+    var found = null;
+    acf.getFields({ name: name }).forEach(function(f) {
+      if ($wrapper.is(f.$el.closest('.acf-fields'))) {
+        found = f;
+      }
+    });
+    return found;
+  }
+
+  function ensureMigrateLink(legacyField, legacyName, wrapKey) {
+    var $input = legacyField.$el.find('.acf-input').first();
+    if (!$input.length) {
+      return;
+    }
+    // Always rebuild: a stale link left over from a prior render (detached
+    // DOM ACF replaced) would otherwise pass an existence check while having
+    // no working click handler on the currently-visible element.
+    $input.find('.wicket-acc-mdp-migrate-link').remove();
+    var $link = jQuery('<p style="margin-top: 4px;"><a href="#" class="wicket-acc-mdp-migrate-link">Copy this value into MDP Widget Config &rarr;</a></p>');
+    $input.append($link);
+
+    $link.find('a').on('click', function(e) {
+      e.preventDefault();
+
+      // Re-resolve both fields at click time rather than trusting closures
+      // captured when the link was created — ACF can tear down and recreate
+      // field instances (e.g. block deselect/reselect) between then and now.
+      try {
+        var currentLegacyField = acf.getField(legacyField.$el) || legacyField;
+        var currentConfigField = findSiblingField(currentLegacyField, 'mdp_json_config');
+
+        if (!currentConfigField) {
+          return;
+        }
+
+        var legacyVal = currentLegacyField.val();
+        if (!legacyVal || !String(legacyVal).trim()) {
+          return;
+        }
+
+        var parsed;
+        try {
+          parsed = JSON.parse(legacyVal);
+        } catch (err) {
+          return;
+        }
+
+        var existingConfigVal = currentConfigField.val();
+        var configObj = {};
+        if (existingConfigVal && String(existingConfigVal).trim()) {
+          try {
+            configObj = JSON.parse(existingConfigVal);
+          } catch (err) {
+            configObj = {};
+          }
+        }
+
+        configObj[wrapKey] = parsed;
+
+        var wrappedStr = JSON.stringify(configObj, null, 2);
+        currentConfigField.val(wrappedStr);
+        currentConfigField.$el.find('textarea').trigger('change').trigger('input');
+
+        // If WP-core CodeMirror is attached to this field (see
+        // wicket-acc-acf-json-editor.js), it shadows the raw textarea with its
+        // own rendered view/buffer — writing to the textarea alone does not
+        // update what's visually displayed. Push the value into CodeMirror too.
+        var cmInstance = currentConfigField.$el.data('wicketAccCmInstance');
+        if (cmInstance && cmInstance.codemirror) {
+          cmInstance.codemirror.setValue(wrappedStr);
+          cmInstance.codemirror.refresh();
+        }
+
+        // Purge the legacy field now that its value has been migrated —
+        // both the raw value (so nothing stale gets saved) and, if
+        // CodeMirror is attached, its shadow view.
+        currentLegacyField.val('');
+        currentLegacyField.$el.find('textarea').trigger('change').trigger('input');
+        var legacyCmInstance = currentLegacyField.$el.data('wicketAccCmInstance');
+        if (legacyCmInstance && legacyCmInstance.codemirror) {
+          legacyCmInstance.codemirror.setValue('');
+          legacyCmInstance.codemirror.refresh();
+        }
+
+        hideLegacyFieldIfEmpty(currentLegacyField);
+      } catch (outerErr) {
+        window.console && console.error('Wicket ACC: unexpected error migrating legacy MDP field value', outerErr);
+      }
+    });
+  }
+
+  function hideLegacyFieldIfEmpty(legacyField) {
+    var val = legacyField.val();
+    if (!val || !String(val).trim()) {
+      legacyField.$el.hide();
+    } else {
+      legacyField.$el.show();
+    }
+  }
+
+  // mdp_json_sections is only wired up (has a working component arg to feed)
+  // on the Individual Profile block. On the Org Profile block it's a dead
+  // field the org profile widget component has never supported — kept only so
+  // a previously-saved value stays visible to whoever configured the block,
+  // not so it can be usefully migrated. Detect which block we're in via a
+  // sibling field unique to the org block's ACF group.
+  function isInertOrgSectionsField(legacyField, legacyName) {
+    return legacyName === 'mdp_json_sections' && !!findSiblingField(legacyField, 'hide_alternate_name_field');
+  }
+
+  function handleLegacyField(legacyField, legacyName) {
+    if (isInertOrgSectionsField(legacyField, legacyName)) {
+      // No migrate link (there is nothing meaningful to migrate into config —
+      // the widget ignores this value either way) and never auto-hide, even
+      // when empty — this field's only job now is staying visible so a
+      // previously-saved value is never hidden from the person configuring
+      // the block.
+      return;
+    }
+
+    ensureMigrateLink(legacyField, legacyName, LEGACY_WRAP_KEYS[legacyName]);
+    // Covers the post-save/reload case: once the legacy value was purged and
+    // saved, the field loads empty on the next page load and should stay hidden.
+    hideLegacyFieldIfEmpty(legacyField);
+  }
+
+  Object.keys(LEGACY_WRAP_KEYS).forEach(function(legacyName) {
+    acf.addAction('ready_field/name=' + legacyName, function(legacyField) {
+      handleLegacyField(legacyField, legacyName);
+    });
+    acf.addAction('append_field/name=' + legacyName, function(legacyField) {
+      handleLegacyField(legacyField, legacyName);
+    });
+  });
+})(jQuery);

--- a/assets/js/wicket-acc-acf-json-editor.js
+++ b/assets/js/wicket-acc-acf-json-editor.js
@@ -1,0 +1,73 @@
+/**
+ * Attaches WP core's bundled CodeMirror (JSON mode, with jsonlint) to the
+ * `mdp_json_config` ACF field on the AC Individual/Org Profile blocks, in the
+ * block editor. Purely cosmetic: line numbers, syntax coloring, live lint,
+ * and code folding on top of the plain `<textarea>` ACF already renders and
+ * saves — the textarea stays the source of truth, and this script keeps its
+ * value in sync via `.trigger('change')` so ACF's own saving is unaffected.
+ * Falls back to the plain textarea if `wp_enqueue_code_editor()` returned
+ * `false` (user has "Disable syntax highlighting when editing code" set).
+ *
+ * Deliberately excludes the legacy `mdp_json_fields`/`mdp_json_sections`
+ * fields — see `wicket-acc-acf-field-deprecation.js` for why those stay
+ * plain text.
+ */
+(function($) {
+  if (typeof acf === 'undefined' || typeof wp === 'undefined' || !wp.codeEditor || typeof WicketAccJsonEditorSettings === 'undefined') {
+    return;
+  }
+
+  if (!WicketAccJsonEditorSettings || Object.keys(WicketAccJsonEditorSettings).length === 0) {
+    // wp_enqueue_code_editor() returned false (syntax highlighting disabled in the
+    // user's profile) — fall back to the plain textarea, no CodeMirror.
+    return;
+  }
+
+  // Legacy mdp_json_fields/mdp_json_sections intentionally stay plain textareas.
+  var JSON_FIELD_NAMES = ['mdp_json_config'];
+
+  function attachEditor(field) {
+    if (!field || !field.$el || field.$el.data('wicketAccCmAttached')) {
+      return;
+    }
+    var $textarea = field.$el.find('textarea').first();
+    if (!$textarea.length) {
+      return;
+    }
+
+    var editorSettings = wp.codeEditor.defaultSettings ? _.clone(wp.codeEditor.defaultSettings) : {};
+    editorSettings.codemirror = _.extend({}, editorSettings.codemirror, WicketAccJsonEditorSettings.codemirror, {
+      indentWithTabs: false,
+      indentUnit: 2,
+      foldGutter: true,
+      gutters: (WicketAccJsonEditorSettings.codemirror.gutters || []).concat(['CodeMirror-foldgutter']),
+    });
+
+    var instance = wp.codeEditor.initialize($textarea, editorSettings);
+    field.$el.data('wicketAccCmAttached', true);
+    field.$el.data('wicketAccCmInstance', instance);
+
+    instance.codemirror.on('change', function() {
+      instance.codemirror.save();
+      $textarea.trigger('change');
+    });
+  }
+
+  function detachEditor(field) {
+    if (!field || !field.$el || !field.$el.data('wicketAccCmAttached')) {
+      return;
+    }
+    var instance = field.$el.data('wicketAccCmInstance');
+    if (instance && instance.codemirror) {
+      instance.codemirror.toTextArea();
+    }
+    field.$el.removeData('wicketAccCmAttached');
+    field.$el.removeData('wicketAccCmInstance');
+  }
+
+  JSON_FIELD_NAMES.forEach(function(name) {
+    acf.addAction('ready_field/name=' + name, attachEditor);
+    acf.addAction('append_field/name=' + name, attachEditor);
+    acf.addAction('remove_field/name=' + name, detachEditor);
+  });
+})(jQuery);

--- a/docs/engineering/ac-individual-profile.md
+++ b/docs/engineering/ac-individual-profile.md
@@ -2,14 +2,14 @@
 title: "AC Individual Profile Block"
 audience: [developer, agent, implementer]
 php_class: WicketAcc\Blocks\IndividualProfile\init
-source_files: ["includes/blocks/ac-individual-profile/init.php", "includes/blocks/ac-individual-profile/render.php", "includes/blocks/ac-individual-profile/block.json", "includes/acf-json/group_66bd0f5a9fca8.json"]
+source_files: ["includes/blocks/ac-individual-profile/init.php", "includes/blocks/ac-individual-profile/render.php", "includes/blocks/ac-individual-profile/block.json", "includes/acf-json/group_69a5f1b6ea37e.json", "assets/js/wicket-acc-acf-field-deprecation.js", "src/Assets.php"]
 ---
 
 # AC Individual Profile Block
 
 ## Overview
 
-The Individual Profile block renders a single person's profile inside an account area. It pulls data through the `widget-profile-individual` widget and exposes two MDP-driven ACF fields: `mdp_json_fields` and `mdp_json_sections`.
+The Individual Profile block renders a single person's profile inside an account area. It pulls data through the `widget-profile-individual` widget and exposes three MDP-driven ACF fields: `mdp_json_fields`, `mdp_json_sections`, and the newer open-ended `mdp_json_config`.
 
 ## Block Architecture
 
@@ -50,9 +50,67 @@ get_component('widget-profile-individual', [
 
 This is the configuration surface that drives what the individual-profile widget renders for a given person.
 
+### MDP Widget Config (open-ended passthrough)
+
+A third ACF field, `mdp_json_config`, is an open-ended JSON object forwarded verbatim to the
+widget as `widget_config` (any current or future MDP widget option — `fields`, `sections`,
+`resourceLimits`, `resourcePermissions`, etc.) after the base plugin's component strips a small
+blocklist of server-owned connection keys. No option-name validation on this plugin's side.
+
+```php
+$json_config = get_field('mdp_json_config');
+$this->mdp_json_config = json_decode((string) $json_config, true) ?? [];
+
+if (is_array($this->mdp_json_config) && $this->mdp_json_config !== []) {
+    get_component('widget-profile-individual', ['widget_config' => $this->mdp_json_config]);
+    return;
+}
+
+get_component('widget-profile-individual', [
+    'fields'   => $this->mdp_json_fields,
+    'sections' => $this->mdp_json_sections,
+]);
+```
+
+**Precedence (exclusive, not merged):** when `mdp_json_config` is non-empty, both legacy
+`mdp_json_fields` and `mdp_json_sections` are ignored entirely — a populated legacy value sits
+inert. When the config is empty or invalid JSON, the block falls back to the legacy
+fields/sections path unchanged.
+
+**Editor UX:** `mdp_json_config` is the top-most field in the ACF group; the legacy
+`mdp_json_fields`/`mdp_json_sections` fields sit below it, each with "(Deprecated)" appended to
+their label — plain text, no colored notices. Legacy fields stay plain `<textarea>` (no
+CodeMirror; see below). Each legacy field gets its own "Copy this value into MDP Widget Config"
+link (`assets/js/wicket-acc-acf-field-deprecation.js`, enqueued from `src/Assets.php` only on
+block-editor screens) that merges its value into the config field under the matching key
+(`fields` or `sections`), preserving whatever the other key already holds — click-triggered only,
+never automatic. Nothing persists until the block/post is saved.
+
+**Unsatisfiable configs (accepted risk):** the config is schema-agnostic, so it can express
+combinations the MDP widget cannot resolve (e.g. a field marked both required and
+hidden/limited/denied). Neither this block nor the underlying component detects or warns about
+this beyond JSON-syntax validation. See
+[refactor-gf-mdp-widget-config.md](../../../../../wicket-atlas/plans/refactor-gf-mdp-widget-config.md)
+for the full plan and risk writeup.
+
+### Editor UI (CodeMirror, config field only)
+
+Only the `mdp_json_config` ACF textarea gets WP core's bundled CodeMirror (line numbers,
+JSON syntax coloring, live lint) in the block editor — the deprecated legacy fields
+(`mdp_json_fields`, `mdp_json_sections`) intentionally stay plain textareas.
+`src/Assets.php::enqueue_admin_assets()` calls `wp_enqueue_code_editor(['type' =>
+'application/json'])` gated on `$current_screen->is_block_editor()`, and
+`assets/js/wicket-acc-acf-json-editor.js` attaches it via ACF's `ready_field`/`append_field`
+lifecycle actions (and detaches on `remove_field`, so it survives block duplication/removal
+cleanly). The textarea remains the source of truth; ACF's own value saving is unaffected.
+Falls back to a plain textarea when `wp_enqueue_code_editor()` returns `false` (user has
+"Disable syntax highlighting when editing code" set in their profile).
+
 ## Recent Changes
 
 - Added `mdp_json_sections` config so editors can declare the section order independently from the field list.
+- Added open-ended `mdp_json_config` passthrough with exclusive precedence over the legacy fields/sections config. `mdp_json_config` is now the top-most field in the group; legacy fields are labeled "(Deprecated)", stay plain text/textarea (no CodeMirror), and each carries a "Copy this value into MDP Widget Config" link.
+- Added CodeMirror JSON editor UI to the `mdp_json_config` textarea in the block editor.
 
 ## Related Documentation
 

--- a/docs/engineering/ac-org-profile.md
+++ b/docs/engineering/ac-org-profile.md
@@ -46,14 +46,14 @@ The block reads these ACF fields:
 - `hide_alternate_name_field` — adds `alternateName` to the widget's `hiddenFields`. Since the shared component has no dedicated `hidden_fields` arg for the org widget, this is passed via `widget_config['hiddenFields']`.
 - `mdp_json_fields` — JSON string decoded into the `fields` array passed to the component. Legacy; ignored entirely when `mdp_json_config` is set.
 - `mdp_json_config` — open-ended JSON object forwarded verbatim to the component as `widget_config` (any current or future MDP widget option). See "MDP Widget Config" below.
-- `mdp_json_sections` — **inert.** This field is never read by `init.php` and has no effect: the
-  org profile widget component has no `sections` arg (unlike the individual profile component), so
-  any value ever saved here has always been silently dropped at render time — before and after the
-  widget-config refactor. It's kept in the ACF group, visible and unhidden, purely so a value saved
-  before this was noticed isn't hidden from whoever configured the block. It gets no migrate link
-  and no CodeMirror (see `assets/js/wicket-acc-acf-field-deprecation.js`,
-  `isInertOrgSectionsField()`). Use `mdp_json_config`'s `sections` key instead if the MDP widget
-  ever adds real section support for organization profiles.
+- `mdp_json_sections` — **inert at render, but migratable.** This field is never read by
+  `init.php` and has no effect: the org profile widget component has no `sections` arg (unlike the
+  individual profile component), so any value ever saved here has always been silently dropped at
+  render time — before and after the widget-config refactor. It still gets the standard "Copy this
+  value into MDP Widget Config" migrate link and auto-hide-when-empty behavior
+  (`assets/js/wicket-acc-acf-field-deprecation.js`), writing into `mdp_json_config`'s `sections`
+  key — so a previously-saved value has somewhere to go, ready for if the org widget ever adds real
+  section support. No CodeMirror (deprecated field, plain textarea like the other legacy fields).
 
 ### Language And API
 
@@ -132,7 +132,7 @@ plain textareas.
 ## Recent Changes
 
 - **Refactored onto the shared `widget-profile-org` base-plugin component** (previously inline `editOrganizationProfile` call, predating the component). Added open-ended `mdp_json_config` passthrough with exclusive precedence over the legacy fields config. `hide_alternate_name_field` now flows through `widget_config['hiddenFields']` instead of a direct `hiddenFields` widget-init arg.
-- **`mdp_json_sections` confirmed inert** — the org profile component never had a `sections` arg, so this field has never had any effect (not a regression from this refactor). Relabeled "(Deprecated, Inactive)" with instructions saying so plainly; excluded from the migrate-link and auto-hide behavior that applies to `mdp_json_fields` (see `assets/js/wicket-acc-acf-field-deprecation.js`, `isInertOrgSectionsField()`), so it stays visible rather than disappearing or offering a migrate action that wouldn't do anything useful.
+- **`mdp_json_sections` confirmed inert at render** — the org profile component never had a `sections` arg, so this field has never had any effect on output (not a regression from this refactor). Relabeled "(Deprecated)" with instructions saying so plainly. Still gets the standard migrate link and auto-hide behavior shared with `mdp_json_fields` (see `assets/js/wicket-acc-acf-field-deprecation.js`) — a saved value can be moved into `mdp_json_config`'s `sections` key even though the widget currently ignores it, so nothing is stranded if section support is ever added.
 - `mdp_json_config` moved to the top of the field group; the legacy `mdp_json_fields` field relabeled "(Deprecated)", kept plain text/textarea (no CodeMirror), with a "Copy this value into MDP Widget Config" link.
 - Added CodeMirror JSON editor UI to the `mdp_json_config` textarea in the block editor.
 

--- a/docs/engineering/ac-org-profile.md
+++ b/docs/engineering/ac-org-profile.md
@@ -2,14 +2,14 @@
 title: "AC Org Profile Block"
 audience: [developer, agent, implementer]
 php_class: WicketAcc\Blocks\OrgProfile\init
-source_files: ["includes/blocks/ac-org-profile/init.php", "includes/blocks/ac-org-profile/render.php", "includes/blocks/ac-org-profile/block.json", "includes/acf-json/group_69a5f1b6ea37e.json"]
+source_files: ["includes/blocks/ac-org-profile/init.php", "includes/blocks/ac-org-profile/render.php", "includes/blocks/ac-org-profile/block.json", "includes/acf-json/group_66bd0f5a9fca8.json", "../wicket-wp-base-plugin/includes/components/widget-profile-org.php"]
 ---
 
 # AC Org Profile Block
 
 ## Overview
 
-The Org Profile block renders and edits a single organization's profile inside the account area. It mounts the `Wicket.widgets.editOrganizationProfile` widget and passes the MDP field/section config into the widget so editors can configure what is shown.
+The Org Profile block renders and edits a single organization's profile inside the account area. It renders through the base plugin's shared `widget-profile-org` component (as of the widget-config refactor — previously it mounted `Wicket.widgets.editOrganizationProfile` inline, predating the component's creation) and passes the MDP field config through so editors can configure what is shown. Unlike the individual profile component, `widget-profile-org` has no `sections` arg — there is no org equivalent of the individual block's `mdp_json_sections`.
 
 ## Block Architecture
 
@@ -42,38 +42,99 @@ If no org is in the URL, the block falls back to the user's `org_editor` role as
 
 The block reads these ACF fields:
 
-- `hide_additional_info` — hides the additional-info widget when truthy.
-- `hide_alternate_name_field` — adds `alternateName` to the widget's `hiddenFields`.
-- `mdp_json_fields` — JSON string decoded into the `fields` array passed to the widget.
-- `mdp_json_sections` — JSON string decoded into the `sections` array passed to the widget.
-
-`mdp_json_sections` lets editors declare the section order independently from the field list.
+- `hide_additional_info` — hides the additional-info widget when truthy. Block-side toggle, untouched by the widget-config refactor.
+- `hide_alternate_name_field` — adds `alternateName` to the widget's `hiddenFields`. Since the shared component has no dedicated `hidden_fields` arg for the org widget, this is passed via `widget_config['hiddenFields']`.
+- `mdp_json_fields` — JSON string decoded into the `fields` array passed to the component. Legacy; ignored entirely when `mdp_json_config` is set.
+- `mdp_json_config` — open-ended JSON object forwarded verbatim to the component as `widget_config` (any current or future MDP widget option). See "MDP Widget Config" below.
+- `mdp_json_sections` — **inert.** This field is never read by `init.php` and has no effect: the
+  org profile widget component has no `sections` arg (unlike the individual profile component), so
+  any value ever saved here has always been silently dropped at render time — before and after the
+  widget-config refactor. It's kept in the ACF group, visible and unhidden, purely so a value saved
+  before this was noticed isn't hidden from whoever configured the block. It gets no migrate link
+  and no CodeMirror (see `assets/js/wicket-acc-acf-field-deprecation.js`,
+  `isInertOrgSectionsField()`). Use `mdp_json_config`'s `sections` key instead if the MDP widget
+  ever adds real section support for organization profiles.
 
 ### Language And API
 
-- Uses `WACC()->Language()->getCurrentLanguage()` to resolve the active language (WPML / Polylang / site default).
-- Pulls the org through `WACC()->Mdp()->Organization()->getOrganizationByUuid()` and mints an org-scoped access token via `wicket_get_access_token($person_uuid, $org_id)`.
+- Uses `WACC()->Language()->getCurrentLanguage()` to resolve the active language (WPML / Polylang / site default) — genuinely more robust than the component's own fallback (see below).
+- Pulls the org through `WACC()->Mdp()->Organization()->getOrganizationByUuid()` and mints an org-scoped access token via `wicket_get_access_token($person_uuid, $org_id)` — unchanged by the refactor; the shared component derives the token the same way internally.
 
-### Widget Integration
+### Widget Integration (refactored onto the shared component)
 
-The block mounts the org-profile widget:
+The block now renders through `get_component('widget-profile-org', ...)` (base plugin,
+`includes/components/widget-profile-org.php`) instead of an inline
+`Wicket.widgets.editOrganizationProfile` call:
 
-```js
-Wicket.widgets.editOrganizationProfile({
-    rootEl: widgetRoot,
-    apiRoot: wicket_settings['api_endpoint'],
-    accessToken: access_token,
-    orgId: org_id,
-    lang: lang,
-    fields: mdp_json_fields,
-    sections: mdp_json_sections, // when present
-    hiddenFields: ['alternateName', ...]
-});
+```php
+if (is_array($widget_config) && $widget_config !== []) {
+    if (!empty($hidden_fields)) {
+        $widget_config['hiddenFields'] = $hidden_fields;
+    }
+    $widget_config['lang'] = $lang;
+    get_component('widget-profile-org', [
+        'org_id'        => $org_id,
+        'widget_config' => $widget_config,
+    ]);
+} else {
+    get_component('widget-profile-org', [
+        'org_id'   => $org_id,
+        'fields'   => $mdp_json_fields,
+        'widget_config' => ['lang' => $lang, 'hiddenFields' => $hidden_fields], // hiddenFields only when non-empty
+    ]);
+}
 ```
+
+**`lang` is routed through `widget_config`, not left to the component's default (post-refactor
+fix, caught in review after ship).** The component has no dedicated `lang` arg — left alone, it
+falls back to `defined('ICL_LANGUAGE_CODE') ? ICL_LANGUAGE_CODE : 'en'`, a much weaker check than
+`WACC()->Language()->getCurrentLanguage()` (no Polylang support, no WP-locale fallback, and
+`ICL_LANGUAGE_CODE` is an older WPML constant). The block already computes `$lang` correctly for
+the Additional Info widget mount below; the initial refactor forgot to also route it into the
+org-profile widget's own call, so non-English/non-WPML-primary-language editors briefly got the
+wrong widget language after the refactor landed. Fixed by adding `$widget_config['lang'] = $lang`
+in both branches — last-wins emit order in the component means this always overrides the
+component's own fallback.
+
+The additional-info widget mount (`Wicket.widgets.editAdditionalInfo`), the `hide_additional_info`
+toggle, and all org-selection/chooser logic stay block-side and are untouched — only the
+`editOrganizationProfile` mount moved to the component. The component emits its own `window.Wicket`
+bootstrap loader (guarded against double-definition), its own wrapper `<div>`, an
+`<h2>Organization Profile</h2>` heading, and hidden inputs (`org_info_data_field_name` etc.) that
+the inline version did not have — the block's own `<h2>Profile</h2>` heading was dropped to avoid a
+duplicate heading. Minor markup/DOM differences vs. the pre-refactor block are expected and are not
+pixel-parity bugs.
+
+`component_exists('widget-profile-org')` is checked before rendering, matching the GF org field's
+defensive pattern — shows a "please update the Wicket Base Plugin" message if the component is
+missing rather than fataling.
+
+### MDP Widget Config (open-ended passthrough)
+
+Same pattern as the [Individual Profile block](ac-individual-profile.md#mdp-widget-config-open-ended-passthrough):
+exclusive precedence over the legacy `mdp_json_fields` (config replaces it, not merged).
+`mdp_json_config` is the top-most field in the ACF group; the legacy field sits below it,
+labeled "(Deprecated)" in plain text, stays plain `<textarea>` (no CodeMirror), and carries a
+"Copy this value into MDP Widget Config" link
+(`assets/js/wicket-acc-acf-field-deprecation.js`, shared across both AC profile blocks since it
+matches by ACF field name) that merges its value into the config field under the `fields` key —
+click-triggered only, never automatic. Same accepted risk as the individual block: a
+schema-agnostic config can express unsatisfiable option combinations the widget cannot resolve.
+See [refactor-gf-mdp-widget-config.md](../../../../../wicket-atlas/plans/refactor-gf-mdp-widget-config.md).
+
+### Editor UI (CodeMirror, config field only)
+
+Same CodeMirror JSON editor as the [Individual Profile block](ac-individual-profile.md#editor-ui-codemirror-config-field-only) —
+`assets/js/wicket-acc-acf-json-editor.js` is shared across both AC profile blocks (matches by
+ACF field name), and only attaches to `mdp_json_config`; the deprecated legacy fields stay
+plain textareas.
 
 ## Recent Changes
 
-- Added `mdp_json_sections` config so editors can declare the section order independently from the field list.
+- **Refactored onto the shared `widget-profile-org` base-plugin component** (previously inline `editOrganizationProfile` call, predating the component). Added open-ended `mdp_json_config` passthrough with exclusive precedence over the legacy fields config. `hide_alternate_name_field` now flows through `widget_config['hiddenFields']` instead of a direct `hiddenFields` widget-init arg.
+- **`mdp_json_sections` confirmed inert** — the org profile component never had a `sections` arg, so this field has never had any effect (not a regression from this refactor). Relabeled "(Deprecated, Inactive)" with instructions saying so plainly; excluded from the migrate-link and auto-hide behavior that applies to `mdp_json_fields` (see `assets/js/wicket-acc-acf-field-deprecation.js`, `isInertOrgSectionsField()`), so it stays visible rather than disappearing or offering a migrate action that wouldn't do anything useful.
+- `mdp_json_config` moved to the top of the field group; the legacy `mdp_json_fields` field relabeled "(Deprecated)", kept plain text/textarea (no CodeMirror), with a "Copy this value into MDP Widget Config" link.
+- Added CodeMirror JSON editor UI to the `mdp_json_config` textarea in the block editor.
 
 ## Related Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ audience: [implementer, support, developer, end-user]
 - [AC Individual Profile Block](engineering/ac-individual-profile.md) — Person profile display block (with `mdp_json_fields` / `mdp_json_sections`)
 - [AC Manage Preferences Block](engineering/ac-manage-preferences.md) — Communication preferences block
 - [AC Org Logo Block](engineering/ac-org-logo.md) — Organization logo block with 404 fallback chain
-- [AC Org Profile Block](engineering/ac-org-profile.md) — Organization profile display/edit block (with `mdp_json_sections`)
+- [AC Org Profile Block](engineering/ac-org-profile.md) — Organization profile display/edit block (with `mdp_json_config`; `mdp_json_sections` is inert, kept only for visibility of previously-saved values)
 - [AC Org Search Select Block](engineering/ac-org-search-select.md) — Organization search/select block
 - [AC Password Block](engineering/ac-password.md) — Password change block (HyperBlocks)
 - [AC Profile Picture Block](engineering/ac-profile-picture.md) — Profile photo upload block with explicit delete flow

--- a/docs/product/organization-profile-view.md
+++ b/docs/product/organization-profile-view.md
@@ -2,7 +2,7 @@
 title: "Organization Profile View"
 audience: [implementer, support]
 php_class: WicketAcc\Blocks\OrgProfile\init
-source_files: ["includes/blocks/ac-org-profile/init.php", "includes/blocks/ac-org-profile/render.php", "includes/blocks/ac-org-profile/block.json", "includes/acf-json/group_69a5f1b6ea37e.json"]
+source_files: ["includes/blocks/ac-org-profile/init.php", "includes/blocks/ac-org-profile/render.php", "includes/blocks/ac-org-profile/block.json", "includes/acf-json/group_66bd0f5a9fca8.json"]
 ---
 
 # Organization Profile View Block
@@ -60,8 +60,9 @@ Wicket.widgets.editOrganizationProfile({
 |       |             |
 | `hide_additional_info` | Toggles the display of the Additional Info widget. |
 | `hide_alternate_name_field` | Explicitly hides the Alternate Name field in the profile editor. |
-| `mdp_json_fields` | A JSON string defining which MDP fields should be editable. |
-| `mdp_json_sections` | A JSON string defining the section order rendered by the widget. |
+| `mdp_json_fields` | A JSON string defining which MDP fields should be editable. Superseded by MDP Widget Config (JSON); see that setting instead for new configuration. |
+| `mdp_json_config` | Open-ended JSON object supporting all MDP JS Widget options (fields, resourceLimits, resourcePermissions, and more). Use this for new configuration. |
+| `mdp_json_sections` | **Inactive** — this setting has never had any effect for organization profiles (the widget has no section-order option here). Do not use; kept visible only so a previously-saved value isn't hidden. |
 
 ## Access Control
 - **Viewing**: Authenticated users associated with the organization.

--- a/includes/acf-json/group_66bd0f5a9fca8.json
+++ b/includes/acf-json/group_66bd0f5a9fca8.json
@@ -108,11 +108,11 @@
         },
         {
             "key": "field_69a6f273d3cd7",
-            "label": "MDP JSON Sections (Deprecated, Inactive)",
+            "label": "MDP JSON Sections (Deprecated)",
             "name": "mdp_json_sections",
             "aria-label": "",
             "type": "textarea",
-            "instructions": "This field never had an effect on this block — the organization profile widget component does not support a sections option, unlike the individual profile widget. Kept visible only so any value saved here previously is not silently hidden. Please do not modify.",
+            "instructions": "This field has no effect on this block — the organization profile widget component does not support a sections option, unlike the individual profile widget. Superseded by the MDP Widget Config setting above. A \"Copy this value into MDP Widget Config\" link appears below this field in the editor to copy it over pre-formatted, in case the widget gains section support later.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
@@ -147,5 +147,5 @@
     "description": "",
     "show_in_rest": 0,
     "display_title": "",
-    "modified": 1780272000
+    "modified": 1784233545
 }

--- a/includes/acf-json/group_66bd0f5a9fca8.json
+++ b/includes/acf-json/group_66bd0f5a9fca8.json
@@ -65,12 +65,33 @@
             "ui": 1
         },
         {
+            "key": "field_69a6f273d3cd8",
+            "label": "MDP Widget Config (JSON)",
+            "name": "mdp_json_config",
+            "aria-label": "",
+            "type": "textarea",
+            "instructions": "<p>This expects JSON data for configuring the widget, supporting all options documented for the MDP JS Widget (<code>fields<\/code>, <code>resourceLimits<\/code>, <code>resourcePermissions<\/code>, and more). Please do not modify unless you know what you are doing.<\/p><p>Note: <code>rootEl<\/code>, <code>apiRoot<\/code>, <code>accessToken<\/code>, and <code>orgId<\/code> are always set automatically and any value provided for them here is ignored.<\/p><p>See <a href=\"https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html#editorganizationprofile\" target=\"_blank\">full documentation for MDP JS Widgets<\/a>.<\/p>",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "maxlength": "",
+            "allow_in_bindings": 0,
+            "rows": "",
+            "placeholder": "{\n  \"fields\": {...}\n}",
+            "new_lines": ""
+        },
+        {
             "key": "field_69a6f273d3cd6",
-            "label": "MDP JSON Fields",
+            "label": "MDP JSON Fields (Deprecated)",
             "name": "mdp_json_fields",
             "aria-label": "",
             "type": "textarea",
-            "instructions": "This expects JSON data for the fields property as defined here: <a href=\"https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html#editorganizationprofile\" target=\"_blank\">https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html<\/a>. Please do not modify unless you know what you are doing. This must be valid JSON, otherwise this field is ignored.",
+            "instructions": "This expects JSON data for the fields property as defined here: <a href=\"https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html#editorganizationprofile\" target=\"_blank\">https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html<\/a>. Please do not modify unless you know what you are doing. This must be valid JSON, otherwise this field is ignored. Superseded by the MDP Widget Config setting above — if that is set, this value is ignored entirely. A \"Copy this value into MDP Widget Config\" link appears below this field in the editor to copy it over pre-formatted.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
@@ -87,11 +108,11 @@
         },
         {
             "key": "field_69a6f273d3cd7",
-            "label": "MDP JSON Sections",
+            "label": "MDP JSON Sections (Deprecated, Inactive)",
             "name": "mdp_json_sections",
             "aria-label": "",
             "type": "textarea",
-            "instructions": "This expects JSON data for the sections property (address \/ email \/ phone \/ web field config) as defined here: <a href=\"https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html#addresssectionconfig\" target=\"_blank\">https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html#addresssectionconfig<\/a>. Please do not modify unless you know what you are doing. This must be valid JSON, otherwise this field is ignored.",
+            "instructions": "This field never had an effect on this block — the organization profile widget component does not support a sections option, unlike the individual profile widget. Kept visible only so any value saved here previously is not silently hidden. Please do not modify.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
@@ -103,7 +124,7 @@
             "maxlength": "",
             "allow_in_bindings": 0,
             "rows": "",
-            "placeholder": "{\"addresses\": { \"fields\": { \"companyName\": { \"readOnly\": true } } }}",
+            "placeholder": "",
             "new_lines": ""
         }
     ],

--- a/includes/acf-json/group_69a5f1b6ea37e.json
+++ b/includes/acf-json/group_69a5f1b6ea37e.json
@@ -3,12 +3,33 @@
     "title": "ACC Individual Profile",
     "fields": [
         {
+            "key": "field_69a5f1b8267eb",
+            "label": "MDP Widget Config (JSON)",
+            "name": "mdp_json_config",
+            "aria-label": "",
+            "type": "textarea",
+            "instructions": "<p>This expects JSON data for configuring the widget, supporting all options documented for the MDP JS Widget (<code>fields<\/code>, <code>sections<\/code>, <code>resourceLimits<\/code>, <code>resourcePermissions<\/code>, and more). Please do not modify unless you know what you are doing.<\/p><p>Note: <code>rootEl<\/code>, <code>apiRoot<\/code>, <code>accessToken<\/code>, and <code>personId<\/code>\/<code>orgId<\/code> are always set automatically and any value provided for them here is ignored.<\/p><p>See <a href=\"https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html#createpersonprofile\" target=\"_blank\">full documentation for MDP JS Widgets<\/a>.<\/p>",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "maxlength": "",
+            "allow_in_bindings": 0,
+            "rows": "",
+            "placeholder": "{\n  \"fields\": {...},\n  \"sections\": {...}\n}",
+            "new_lines": ""
+        },
+        {
             "key": "field_69a5f1b8267e9",
-            "label": "MDP JSON Fields",
+            "label": "MDP JSON Fields (Deprecated)",
             "name": "mdp_json_fields",
             "aria-label": "",
             "type": "textarea",
-            "instructions": "This expects JSON data for the fields property as defined here: <a href=\"https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html#createpersonprofile\" target=\"_blank\">https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html#createpersonprofile<\/a>. Please do not modify unless you know what you are doing. This must be valid JSON, otherwise this field is ignored.",
+            "instructions": "This expects JSON data for the fields property as defined here: <a href=\"https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html#createpersonprofile\" target=\"_blank\">https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html#createpersonprofile<\/a>. Please do not modify unless you know what you are doing. This must be valid JSON, otherwise this field is ignored. Superseded by the MDP Widget Config setting above — if that is set, this value is ignored entirely. A \"Copy this value into MDP Widget Config\" link appears below this field in the editor to copy it over pre-formatted.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
@@ -25,11 +46,11 @@
         },
         {
             "key": "field_69a5f1b8267ea",
-            "label": "MDP JSON Sections",
+            "label": "MDP JSON Sections (Deprecated)",
             "name": "mdp_json_sections",
             "aria-label": "",
             "type": "textarea",
-            "instructions": "This expects JSON data for the sections property (address \/ email \/ phone \/ web field config) as defined here: <a href=\"https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html#addresssectionconfig\" target=\"_blank\">https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html#addresssectionconfig<\/a>. Please do not modify unless you know what you are doing. This must be valid JSON, otherwise this field is ignored.",
+            "instructions": "This expects JSON data for the sections property (address \/ email \/ phone \/ web field config) as defined here: <a href=\"https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html#addresssectionconfig\" target=\"_blank\">https:\/\/wicket-core.s3.ca-central-1.amazonaws.com\/wicket-widgets-readme-staging.html#addresssectionconfig<\/a>. Please do not modify unless you know what you are doing. This must be valid JSON, otherwise this field is ignored. Superseded by the MDP Widget Config setting above — if that is set, this value is ignored entirely.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {

--- a/includes/blocks/ac-individual-profile/init.php
+++ b/includes/blocks/ac-individual-profile/init.php
@@ -61,7 +61,7 @@ class init extends Blocks
      */
     protected function init_block()
     {
-        if (is_array($this->mdp_json_config) && $this->mdp_json_config !== []) {
+        if (is_array($this->mdp_json_config) && !empty($this->mdp_json_config) && !array_is_list($this->mdp_json_config)) {
             get_component('widget-profile-individual', [
                 'widget_config' => $this->mdp_json_config,
             ]);

--- a/includes/blocks/ac-individual-profile/init.php
+++ b/includes/blocks/ac-individual-profile/init.php
@@ -14,13 +14,20 @@ class init extends Blocks
 {
     /**
      * @var string
+     * @deprecated Superseded by mdp_json_config; kept for legacy saved blocks.
      */
     protected array $mdp_json_fields = [];
 
     /**
      * @var array
+     * @deprecated Superseded by mdp_json_config; kept for legacy saved blocks.
      */
     protected array $mdp_json_sections = [];
+
+    /**
+     * @var array
+     */
+    protected array $mdp_json_config = [];
 
     /**
      * Constructor.
@@ -32,11 +39,16 @@ class init extends Blocks
         $this->block = $block;
         $this->is_preview = $is_preview;
 
+        // Deprecated: mdp_json_fields/mdp_json_sections are superseded by
+        // mdp_json_config (see init_block()); kept working for existing saved blocks.
         $json_fields = get_field('mdp_json_fields');
         $this->mdp_json_fields = json_decode($json_fields, true) ?? [];
 
         $json_sections = get_field('mdp_json_sections');
         $this->mdp_json_sections = json_decode($json_sections, true) ?? [];
+
+        $json_config = get_field('mdp_json_config');
+        $this->mdp_json_config = json_decode((string) $json_config, true) ?? [];
 
         // Display the block
         $this->init_block();
@@ -49,6 +61,16 @@ class init extends Blocks
      */
     protected function init_block()
     {
+        if (is_array($this->mdp_json_config) && $this->mdp_json_config !== []) {
+            get_component('widget-profile-individual', [
+                'widget_config' => $this->mdp_json_config,
+            ]);
+
+            return;
+        }
+
+        // Deprecated fallback: mdp_json_fields/mdp_json_sections only render when
+        // mdp_json_config is empty/invalid.
         get_component('widget-profile-individual', [
             'fields'   => $this->mdp_json_fields,
             'sections' => $this->mdp_json_sections,

--- a/includes/blocks/ac-org-profile/init.php
+++ b/includes/blocks/ac-org-profile/init.php
@@ -128,7 +128,8 @@ class init extends Blocks
 
                 if (is_array($widget_config) && $widget_config !== []) {
                     if (!empty($hidden_fields)) {
-                        $widget_config['hiddenFields'] = $hidden_fields;
+                        $existing_hidden_fields = isset($widget_config['hiddenFields']) && is_array($widget_config['hiddenFields']) ? $widget_config['hiddenFields'] : [];
+                        $widget_config['hiddenFields'] = array_values(array_unique(array_merge($hidden_fields, $existing_hidden_fields)));
                     }
                     // The component has no dedicated 'lang' arg — it falls back to a
                     // bare ICL_LANGUAGE_CODE check with no Polylang/WP-locale support.

--- a/includes/blocks/ac-org-profile/init.php
+++ b/includes/blocks/ac-org-profile/init.php
@@ -127,7 +127,7 @@ class init extends Blocks
                 $json_config = get_field('mdp_json_config');
                 $widget_config = json_decode((string) $json_config, true) ?? [];
 
-                if (is_array($widget_config) && $widget_config !== []) {
+                if (is_array($widget_config) && !empty($widget_config) && !array_is_list($widget_config)) {
                     if (!empty($hidden_fields)) {
                         $existing_hidden_fields = isset($widget_config['hiddenFields']) && is_array($widget_config['hiddenFields']) ? $widget_config['hiddenFields'] : [];
                         $widget_config['hiddenFields'] = array_values(array_unique(array_merge($hidden_fields, $existing_hidden_fields)));

--- a/includes/blocks/ac-org-profile/init.php
+++ b/includes/blocks/ac-org-profile/init.php
@@ -35,12 +35,13 @@ class init extends Blocks
         // Deprecated: mdp_json_fields is superseded by the mdp_json_config ACF
         // field (see init_block()); kept working for existing saved blocks.
         //
-        // Note: the ACF group also still has an "MDP JSON Sections (Deprecated,
-        // Inactive)" field (mdp_json_sections), but it is never read here — the
-        // org profile widget component has no sections arg, unlike the individual
-        // profile component, so this field never had any effect. It's kept
-        // visible in the editor only so a value saved before this was noticed
-        // isn't silently hidden from whoever configured the block.
+        // Note: the ACF group also still has an "MDP JSON Sections (Deprecated)"
+        // field (mdp_json_sections), but it is never read here — the org profile
+        // widget component has no sections arg, unlike the individual profile
+        // component, so this field never had any effect on render. It still gets
+        // the standard migrate link into mdp_json_config's `sections` key (see
+        // assets/js/wicket-acc-acf-field-deprecation.js), so a previously-saved
+        // value isn't stranded if the widget ever gains section support.
         $json_fields = get_field('mdp_json_fields');
         $this->mdp_json_fields = json_decode($json_fields, true) ?? [];
 

--- a/includes/blocks/ac-org-profile/init.php
+++ b/includes/blocks/ac-org-profile/init.php
@@ -14,13 +14,9 @@ class init extends Blocks
 {
     /**
      * @var string
+     * @deprecated Superseded by the mdp_json_config ACF field; kept for legacy saved blocks.
      */
     protected array $mdp_json_fields = [];
-
-    /**
-     * @var array
-     */
-    protected array $mdp_json_sections = [];
 
     /**
      * Constructor.
@@ -36,11 +32,17 @@ class init extends Blocks
         $this->hide_additional_info = get_field('hide_additional_info');
         $this->hide_alternate_name_field = get_field('hide_alternate_name_field');
 
+        // Deprecated: mdp_json_fields is superseded by the mdp_json_config ACF
+        // field (see init_block()); kept working for existing saved blocks.
+        //
+        // Note: the ACF group also still has an "MDP JSON Sections (Deprecated,
+        // Inactive)" field (mdp_json_sections), but it is never read here — the
+        // org profile widget component has no sections arg, unlike the individual
+        // profile component, so this field never had any effect. It's kept
+        // visible in the editor only so a value saved before this was noticed
+        // isn't silently hidden from whoever configured the block.
         $json_fields = get_field('mdp_json_fields');
         $this->mdp_json_fields = json_decode($json_fields, true) ?? [];
-
-        $json_sections = get_field('mdp_json_sections');
-        $this->mdp_json_sections = json_decode($json_sections, true) ?? [];
 
         // Display the block
         $this->init_block();
@@ -111,64 +113,47 @@ class init extends Blocks
         if ($org_id) {
             $wicket_settings = get_wicket_settings();
             $access_token = wicket_get_access_token(wicket_current_person_uuid(), $org_id);
-            ?>
 
-            <div class="wicket-section" role="complementary">
-                <h2><?php _e('Profile', 'wicket-acc'); ?>
-                </h2>
-                <div id="profile"></div>
-            </div>
-
-            <script>
-                window.Wicket = function(doc, tag, id, script) {
-                    var w = window.Wicket || {};
-                    if (doc.getElementById(id)) return w;
-                    var ref = doc.getElementsByTagName(tag)[0];
-                    var js = doc.createElement(tag);
-                    js.id = id;
-                    js.src = script;
-                    ref.parentNode.insertBefore(js, ref);
-                    w._q = [];
-                    w.ready = function(f) {
-                        w._q.push(f)
-                    };
-                    return w
-                }(document, "script", "wicket-widgets",
-                    "<?php echo $wicket_settings['wicket_admin'] ?>/dist/widgets.js"
-                );
-            </script>
-
-            <script>
-                <?php
-                            $hidden_fields = [];
+            $hidden_fields = [];
             if ($this->hide_alternate_name_field) {
                 $hidden_fields[] = 'alternateName';
             }
+
+            if (!component_exists('widget-profile-org')) {
+                echo '<p>' . __('Widget-profile-org component is missing. Please update the Wicket Base Plugin.', 'wicket-acc') . '</p>';
+            } else {
+                $json_config = get_field('mdp_json_config');
+                $widget_config = json_decode((string) $json_config, true) ?? [];
+
+                if (is_array($widget_config) && $widget_config !== []) {
+                    if (!empty($hidden_fields)) {
+                        $widget_config['hiddenFields'] = $hidden_fields;
+                    }
+                    // The component has no dedicated 'lang' arg — it falls back to a
+                    // bare ICL_LANGUAGE_CODE check with no Polylang/WP-locale support.
+                    // $lang (WACC()->Language()->getCurrentLanguage(), resolved above)
+                    // is the correct value the pre-refactor inline call used; route it
+                    // through widget_config so it overrides the component's fallback.
+                    $widget_config['lang'] = $lang;
+                    get_component('widget-profile-org', [
+                        'org_id'        => $org_id,
+                        'widget_config' => $widget_config,
+                    ]);
+                } else {
+                    // Deprecated fallback: mdp_json_fields only renders when the
+                    // mdp_json_config ACF field is empty/invalid.
+                    $component_widget_config = ['lang' => $lang];
+                    if (!empty($hidden_fields)) {
+                        $component_widget_config['hiddenFields'] = $hidden_fields;
+                    }
+                    get_component('widget-profile-org', array_filter([
+                        'org_id'        => $org_id,
+                        'fields'        => $this->mdp_json_fields,
+                        'widget_config' => $component_widget_config,
+                    ], static fn ($value) => $value !== []));
+                }
+            }
             ?>
-
-                    (function() {
-                        Wicket.ready(function() {
-                            var widgetRoot = document.getElementById('profile');
-
-                            Wicket.widgets.editOrganizationProfile({
-                                rootEl: widgetRoot,
-                                apiRoot: '<?php echo $wicket_settings['api_endpoint'] ?>',
-                                accessToken: '<?php echo $access_token ?>',
-                                orgId: '<?php echo $org_id ?>',
-                                lang: "<?php echo $lang; ?>",
-                                fields: <?php echo json_encode($this->mdp_json_fields) ?>,
-                                <?php if (!empty($this->mdp_json_sections)) : ?>
-                                sections: <?php echo json_encode($this->mdp_json_sections) ?>,
-                                <?php endif; ?>
-                                hiddenFields: ['<?php echo implode("', '", $hidden_fields) ?>']
-                            }).then(function(widget) {
-                                widget.listen(widget.eventTypes.SAVE_SUCCESS, function(payload) {
-
-                                });
-                            });
-                        });
-                    })()
-            </script>
 
             <?php if ($this->hide_additional_info == 0) : ?>
                 <div class="wicket-section" role="complementary">

--- a/includes/blocks/ac-org-profile/init.php
+++ b/includes/blocks/ac-org-profile/init.php
@@ -25,6 +25,7 @@ class init extends Blocks
         protected array $block = [],
         protected bool $is_preview = false,
         protected int|string|bool|null $hide_additional_info = 0,
+        protected bool $hide_alternate_name_field = false,
     ) {
         $this->block = $block;
         $this->is_preview = $is_preview;

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -92,6 +92,34 @@ class Assets extends WicketAcc
             'wicket_prefer_color_scheme' => $this->wicketPreferColorScheme,
         ];
         wp_localize_script('wicket-acc-admin-scripts', 'wicketAccSettings', $localized_settings);
+
+        $current_screen = function_exists('get_current_screen') ? get_current_screen() : null;
+        if ($current_screen && $current_screen->is_block_editor()) {
+            $acf_deprecation_js_path = WICKET_ACC_PATH . 'assets/js/wicket-acc-acf-field-deprecation.js';
+            wp_enqueue_script(
+                'wicket-acc-acf-field-deprecation',
+                WICKET_ACC_URL . 'assets/js/wicket-acc-acf-field-deprecation.js',
+                ['acf-input'],
+                file_exists($acf_deprecation_js_path) ? filemtime($acf_deprecation_js_path) : WICKET_ACC_VERSION,
+                true
+            );
+
+            $acf_json_editor_js_path = WICKET_ACC_PATH . 'assets/js/wicket-acc-acf-json-editor.js';
+            wp_enqueue_script(
+                'wicket-acc-acf-json-editor',
+                WICKET_ACC_URL . 'assets/js/wicket-acc-acf-json-editor.js',
+                ['acf-input', 'underscore', 'wp-codemirror'],
+                file_exists($acf_json_editor_js_path) ? filemtime($acf_json_editor_js_path) : WICKET_ACC_VERSION,
+                true
+            );
+
+            $wicket_acc_json_editor_settings = wp_enqueue_code_editor(['type' => 'application/json']);
+            wp_localize_script(
+                'wicket-acc-acf-json-editor',
+                'WicketAccJsonEditorSettings',
+                $wicket_acc_json_editor_settings !== false ? $wicket_acc_json_editor_settings : []
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
Adds an "MDP Widget Config" ACF JSON field to the individual-profile and org-profile blocks, wired through the base-plugin's new `widget_config` passthrough. Site editors can now set any MDP JS Widget option (fields, sections, resource limits/permissions, etc.) directly as JSON on the block, instead of being limited to the old `mdp_json_fields`/`mdp_json_sections` boxes.

- Also refactors the org-profile block onto the shared `widget-profile-org` component (previously inlined its own widget-init script).
- Old `mdp_json_fields`/`mdp_json_sections` fields still work as a deprecated fallback when the new config field is empty, and a "Copy this value into MDP Widget Config" migrate link is provided to move existing content over.
- Restores the org profile block's migrate link/behaviour for `mdp_json_sections` that regressed during the refactor.

## End result
Editors managing an Account Centre profile block get one JSON config box that supports the full MDP widget option set, with a smooth migration path off the old restricted fields.

## Related work
Part of the Wicket Widget Support initiative (WWID-1888). Depends on the `widget_config` passthrough added in wicket-wp-base-plugin; pairs with the equivalent GF field support in wicket-wp-gravity-forms (both branch `wwid-1888-improved-wicket-widget-support`).

Merge order: base-plugin → account-centre / gravity-forms.

Asana: https://app.asana.com/1/1138832104141584/project/1216279585352300/task/1215388151519673