### PR TITLE
feat(org-roster): show group desc, back button, observer default role

### DIFF
--- a/src/WicketORM/Config/OrgManConfig.php
+++ b/src/WicketORM/Config/OrgManConfig.php
@@ -313,6 +313,8 @@ final class OrgManConfig
                     'show_edit_permissions' => false,
                     'add_member_auto_close_on_success' => false,
                     'add_member_auto_close_delay_seconds' => 7,
+                    // Default role preselected in the add-member modal: 'member' or 'observer'.
+                    'add_member_default_role' => 'member',
                     'search_clear_requires_submit' => true,
                     'editable_fields' => [
                         'name',

--- a/src/WicketORM/templates-partials/group-members.php
+++ b/src/WicketORM/templates-partials/group-members.php
@@ -269,6 +269,8 @@ $remove_member_endpoint = WicketORM\Helpers\TemplateHelper::template_url() . 'pr
 $group_roles = is_array($groups_config['roles'] ?? null) ? $groups_config['roles'] : [];
 $member_role = $group_roles['member'] ?? ($groups_config['member_role'] ?? 'member');
 $observer_role = $group_roles['observer'] ?? ($groups_config['observer_role'] ?? 'observer');
+// Default role preselected in the add-member modal: 'member' or 'observer'.
+$default_member_role = $groups_presentation['add_member_default_role'] ?? 'member';
 ?>
 
     <dialog id="groupMembersAddModal"
@@ -332,8 +334,8 @@ $observer_role = $group_roles['observer'] ?? ($groups_config['observer_role'] ??
                     </label>
                     <select id="group-member-role" name="role"
                         class="wt_w-full wt_border wt_border-color wt_rounded-md wt_p-2">
-                        <option value="<?php echo esc_attr($member_role); ?>"><?php esc_html_e('Member', 'wicket-acc'); ?></option>
-                        <option value="<?php echo esc_attr($observer_role); ?>"><?php esc_html_e('Observer', 'wicket-acc'); ?></option>
+                        <option value="<?php echo esc_attr($member_role); ?>"<?php echo $default_member_role !== 'observer' ? ' selected' : ''; ?>><?php esc_html_e('Member', 'wicket-acc'); ?></option>
+                        <option value="<?php echo esc_attr($observer_role); ?>"<?php echo $default_member_role === 'observer' ? ' selected' : ''; ?>><?php esc_html_e('Observer', 'wicket-acc'); ?></option>
                     </select>
                 </div>
 

--- a/src/WicketORM/templates-partials/members-view-unified.php
+++ b/src/WicketORM/templates-partials/members-view-unified.php
@@ -580,9 +580,10 @@ $remove_member_auto_close_enabled = ($mode === 'groups')
                 $group_roles = is_array($groups_config['roles'] ?? null) ? $groups_config['roles'] : [];
                 $member_role = $group_roles['member'] ?? ($groups_config['member_role'] ?? 'member');
                 $observer_role = $group_roles['observer'] ?? ($groups_config['observer_role'] ?? 'observer');
+                $default_member_role = $groups_config['presentation']['add_member_default_role'] ?? ($groups_config['ui']['add_member_default_role'] ?? 'member');
                 ?>
-                            <option value="<?php echo esc_attr($member_role); ?>"><?php esc_html_e('Member', 'wicket-acc'); ?></option>
-                            <option value="<?php echo esc_attr($observer_role); ?>"><?php esc_html_e('Observer', 'wicket-acc'); ?></option>
+                            <option value="<?php echo esc_attr($member_role); ?>"<?php echo $default_member_role !== 'observer' ? ' selected' : ''; ?>><?php esc_html_e('Member', 'wicket-acc'); ?></option>
+                            <option value="<?php echo esc_attr($observer_role); ?>"<?php echo $default_member_role === 'observer' ? ' selected' : ''; ?>><?php esc_html_e('Observer', 'wicket-acc'); ?></option>
                         </select>
                     </div>
 

--- a/src/WicketORM/templates-partials/organization-details.php
+++ b/src/WicketORM/templates-partials/organization-details.php
@@ -41,6 +41,13 @@ if ($roster_mode === 'groups' && $group_uuid && function_exists('wicket_get_grou
         $attrs = $group['data']['attributes'];
         $group_name = $attrs['name'] ?? $attrs['name_en'] ?? $attrs['name_fr'] ?? '';
         $group_type = $attrs['type'] ?? '';
+        $group_description = (string) (
+            $attrs['description']
+            ?? $attrs['description_en']
+            ?? $attrs['description_fr']
+            ?? $attrs['description_es']
+            ?? ''
+        );
     }
     if (empty($org_uuid) && is_array($group)) {
         $org_uuid = (string) ($group['data']['relationships']['organization']['data']['id'] ?? '');
@@ -183,6 +190,9 @@ if ($roster_mode !== 'groups') {
     <div class="org-details__summary-card wt_rounded-card-accent wt_p-4 wt_bg-summary-card">
         <?php if ($roster_mode === 'groups' && $group_name): ?>
             <h2 class="wp-block-heading has-heading-sm-font-size org-details__title wt_text-lg wt_mb-2 wt_text-heading-color wt_font-bold"><?php echo esc_html($group_name); ?></h2>
+            <?php if ($group_description !== '') : ?>
+                <p class="org-details__summary-item wt_leading-normal wt_text-content wt_mb-2"><?php echo esc_html($group_description); ?></p>
+            <?php endif; ?>
             <?php if ($org_name): ?>
                 <p class="org-details__summary-item wt_leading-normal wt_text-content mb-1">
                     <?php esc_html_e('Organization:', 'wicket-acc'); ?>

--- a/src/WicketORM/templates-partials/organization-list.php
+++ b/src/WicketORM/templates-partials/organization-list.php
@@ -130,6 +130,13 @@ do {
         $group_name = $attrs['name'] ?? $attrs['name_en'] ?? $attrs['name_fr'] ?? '';
         $group_type = $attrs['type'] ?? '';
         $group_tags = is_array($attrs) ? ($attrs['tags'] ?? null) : null;
+        $group_description = (string) (
+            $attrs['description']
+            ?? $attrs['description_en']
+            ?? $attrs['description_fr']
+            ?? $attrs['description_es']
+            ?? ''
+        );
         if ($group_name === '' && $group_type === '') {
             $logger->debug('Skipping group item missing name/type', [
                 'source' => 'wicket-orgman',
@@ -144,6 +151,7 @@ do {
         $groups_by_org[$org_map_key][] = [
             'id' => $group_id,
             'name' => $group_name,
+            'description' => $group_description,
             'type' => $group_type,
             'tags' => $group_tags,
             'org_uuid' => $org_uuid,
@@ -194,6 +202,7 @@ if ($roster_mode === 'groups') {
             $manageable_groups[] = [
                 'group_uuid' => $group_id,
                 'group_name' => $group_name,
+                'group_description' => (string) ($group_detail['description'] ?? ''),
                 'org_uuid' => (string) ($group_detail['org_uuid'] ?? ''),
                 'org_identifier' => (string) ($group_detail['org_identifier'] ?? ''),
                 'org_name' => (string) ($group_detail['org_name'] ?? ''),
@@ -382,6 +391,12 @@ if ($roster_mode === 'groups') {
                 <div class="wt_w-full wt_rounded-card-accent wt_p-4 wt_mb-1 wt_hover_shadow-sm wt_transition-shadow wt_bg-card wt_border wt_border-color wt_decoration-none"
                     role="listitem">
                     <div class="wt_text-xl wt_font-semibold wt_text-content"><?php echo esc_html((string) $group_item['group_name']); ?></div>
+                <?php
+                $group_description_text = trim((string) ($group_item['group_description'] ?? ''));
+                ?>
+                <?php if ($group_description_text !== '') : ?>
+                    <div class="wt_text-base wt_text-content wt_mt-1 wt_text-pretty"><?php echo esc_html($group_description_text); ?></div>
+                <?php endif; ?>
                     <?php if ($grp_card_show_org_name && $group_org_label !== '') : ?>
                         <div class="wt_text-sm wt_text-content wt_mt-1">
                             <?php echo esc_html(sprintf(__('Organization: %s', 'wicket-acc'), $group_org_label)); ?>

--- a/src/WicketORM/templates/content-organization-members.php
+++ b/src/WicketORM/templates/content-organization-members.php
@@ -51,6 +51,25 @@ $status = isset($_REQUEST['status']) ? sanitize_text_field(wp_unslash($_REQUEST[
 
 ?>
 <div id="org-management-members-app" class="org-management-app wicket-orgman wt_w-full wt_mt-6 wt_mb-6">
+    <?php
+    // Back to Manage Groups / Organizations landing when the user has drilled into a specific context.
+    $back_to_landing_show = $roster_mode === 'groups' || $org_uuid !== '';
+if ($back_to_landing_show) :
+    $back_to_landing_label = $roster_mode === 'groups'
+        ? __('Back to Manage Groups', 'wicket-acc')
+        : __('Back to Manage Organizations', 'wicket-acc');
+    $back_to_landing_url = \WicketORM\Helpers\Helper::getMyAccountPageUrl(
+        'organization-management',
+        '/my-account/organization-management/'
+    );
+    ?>
+        <a href="<?php echo esc_url($back_to_landing_url); ?>"
+            class="wt_inline-flex wt_items-center wt_gap-1 wt_text-primary-600 wt_hover_text-primary-700 wt_text-sm wt_mb-4 underline underline-offset-4">
+            <span aria-hidden="true">&larr;</span>
+            <?php echo esc_html($back_to_landing_label); ?>
+        </a>
+    <?php endif; ?>
+
     <h2 class="wp-block-heading has-heading-sm-font-size wt_text-2xl wt_font-bold wt_mb-4"><?php echo esc_html($management_title); ?></h2>
 
     <?php if ($status === 'success') : ?>
@@ -61,7 +80,7 @@ $status = isset($_REQUEST['status']) ? sanitize_text_field(wp_unslash($_REQUEST[
 
     <?php if ($roster_mode === 'groups') : ?>
         <?php
-        $group_uuid = isset($_GET['group_uuid']) ? sanitize_text_field((string) $_GET['group_uuid']) : '';
+    $group_uuid = isset($_GET['group_uuid']) ? sanitize_text_field((string) $_GET['group_uuid']) : '';
         if (!empty($group_uuid)) :
             ?>
             <div class="org-management-profile-wrap" id="group-summary">

--- a/src/WicketORM/templates/content-organization-profile.php
+++ b/src/WicketORM/templates/content-organization-profile.php
@@ -54,6 +54,25 @@ $status = isset($_REQUEST['status']) ? sanitize_text_field(wp_unslash($_REQUEST[
 <div id="org-management-index-app"
     class="org-management-app wicket-orgman wt_w-full wt_mt-6 wt_mb-6"
     data-org-type="<?php echo esc_attr($org_type); ?>">
+    <?php
+    // Back to Manage Groups / Organizations landing when the user has drilled into a specific context.
+    $back_to_landing_show = $roster_mode === 'groups' || $org_uuid !== '';
+if ($back_to_landing_show) :
+    $back_to_landing_label = $roster_mode === 'groups'
+        ? __('Back to Manage Groups', 'wicket-acc')
+        : __('Back to Manage Organizations', 'wicket-acc');
+    $back_to_landing_url = \WicketORM\Helpers\Helper::getMyAccountPageUrl(
+        'organization-management',
+        '/my-account/organization-management/'
+    );
+    ?>
+        <a href="<?php echo esc_url($back_to_landing_url); ?>"
+            class="wt_inline-flex wt_items-center wt_gap-1 wt_text-primary-600 wt_hover_text-primary-700 wt_text-sm wt_mb-4 underline underline-offset-4">
+            <span aria-hidden="true">&larr;</span>
+            <?php echo esc_html($back_to_landing_label); ?>
+        </a>
+    <?php endif; ?>
+
     <h1 class="wt_text-2xl wt_font-bold wt_mb-4"><?php echo esc_html($management_title); ?></h1>
 
     <?php if ($status === 'success') : ?>


### PR DESCRIPTION
## What

Three IAA roster adjustments on the manage-groups surface, covering the three subtasks under WWID-1914.

- **Group descriptions** now render in two places they were missing: on each group card in the manage-groups list, and inside the group detail summary card (`org-details__summary-card`). The description is read from the group attributes with language fallbacks (`description` -> `_en` -> `_fr` -> `_es`), matching the existing pattern in `group-profile`.
- **Back button** on both the organization-members and organization-profile detail screens. It returns to the manage-groups landing and only renders when the user has drilled into a specific group or org context.
- **Observer as default role** in the add-member modal, via a new config key `groups.presentation.add_member_default_role` (legacy alias `groups.ui.*`). The schema default stays `member`, so every other client keeps current behavior. IAA opts in by setting it to `observer` in its theme override.

## Why

Sarah reported the group description was visible in the MDP but missing from the Wicket manage-groups UI, asked for a back option on the two detail screens, and requested Observer be preselected when adding a member. The add-member loop bug (WWID-1917) is still under investigation and is not part of this PR.

## How

- `organization-list.php` threads a `group_description` field through the group-detail array and renders it on each card when non-empty.
- `organization-details.php` extracts `$group_description` from the fetched group attributes and renders it directly under the title in the summary card.
- `content-organization-members.php` and `content-organization-profile.php` each get a back link, conditionally shown when `roster_mode === 'groups' || $org_uuid !== ''`, with a label that toggles between "Back to Manage Groups" and "Back to Manage Organizations".
- `OrgManConfig.php` adds `add_member_default_role` (default `member`) to the `groups.presentation` schema; `group-members.php` and `members-view-unified.php` read it and mark the matching `<option selected>`.

## Testing

- [x] `php -l` clean on all 7 files locally and on the IAA staging server.
- [x] Synced to IAA staging (https://iaa-website-wordpress.ind.ninja) and verified file md5 checksums match the branch HEAD.
- [x] Reviewer to confirm on staging: group description shows on list cards and the group detail summary card.
- [x] Reviewer to confirm: back button appears on both detail screens and returns to the manage-groups landing.
- [x] Reviewer to confirm: add-member modal preselects Observer for IAA.

## Notes

- Backward compatible by default. The new config key defaults to `member`; only IAA changes behavior via its theme override.
- The IAA theme override (`org-roster.php`) and the Atlas config snapshot (`atlas/packages/wicket-wp-account-centre/orm-configs/IAA.md`) are updated separately; this PR only touches the product plugin.

https://app.asana.com/1/1138832104141584/task/1216155989747273?focus=true
