### PR TITLE
fix(ac-org-profile): cast hide_alternate_name_field to bool

### DIFF
--- a/includes/blocks/ac-org-profile/init.php
+++ b/includes/blocks/ac-org-profile/init.php
@@ -31,7 +31,7 @@ class init extends Blocks
         $this->is_preview = $is_preview;
 
         $this->hide_additional_info = get_field('hide_additional_info');
-        $this->hide_alternate_name_field = get_field('hide_alternate_name_field');
+        $this->hide_alternate_name_field = (bool) get_field('hide_alternate_name_field');
 
         // Deprecated: mdp_json_fields is superseded by the mdp_json_config ACF
         // field (see init_block()); kept working for existing saved blocks.


### PR DESCRIPTION
## What
Casts the `hide_alternate_name_field` ACF value to `bool` before assigning it to the typed constructor property in the Org Profile block (`includes/blocks/ac-org-profile/init.php`).

## Why
The Manage Organization Profile page raised an uncaught `TypeError` whenever the `hide_alternate_name_field` field had no saved value. `get_field()` returns `null` in that case, and assigning `null` to the strictly typed `bool` property fails under `strict_types`. This took the page down on IAA staging (see `fatal-errors-2026-07-22` in `uploads/wc-logs`, four CRITICAL hits between 16:21 and 16:22 UTC).

A prior change widened the sibling `hide_additional_info` property to `int|string|bool|null` but missed this one. I verified the regression still reproduces in 1.7.14, so this is a live fix rather than cleanup.

## How
One line in the constructor body:

```php
$this->hide_alternate_name_field = (bool) get_field('hide_alternate_name_field');
```

The property keeps its honest `bool` type, and `null` coerces to `false` at the ACF boundary. The only consumer is a truthy check (`if ($this->hide_alternate_name_field)`), so behavior is unchanged for every ACF return shape (true, false, 1, 0, `"1"`, null).

## Testing
- [x] `php -l` passes on the edited file.
- [x] Confirm a block with the field explicitly enabled still hides the Alternate Name field.

WWID-2033
