### PR TITLE
fix: do not require Gravity Forms API directly

### DIFF
--- a/src/WicketORM/Helpers/GravityFormsHelper.php
+++ b/src/WicketORM/Helpers/GravityFormsHelper.php
@@ -11,10 +11,12 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-// Include Gravity Forms API
-if (!class_exists('GFAPI')) {
-    require_once WP_PLUGIN_DIR . '/gravityforms/includes/api.php';
-}
+// Gravity Forms loads its own API: gravityforms.php requires includes/api.php.
+// Never require that file directly. It calls die() unless GFForms is already
+// loaded, so requiring it while Gravity Forms is deactivated terminates the
+// request with no error, no log entry, and an empty HTTP 200 response.
+// Availability is gated by the class_exists('GFForms') check in init() below,
+// and by the matching check in the template that calls get_form_html().
 
 /**
  * Helper functions for Gravity Forms integration.


### PR DESCRIPTION
## Purpose

Deactivating Gravity Forms makes any site running this plugin go completely blank, with no error, no `debug.log` entry, and an empty HTTP 200 response.

`GravityFormsHelper.php` required `gravityforms/includes/api.php` at **file scope**, guarded only by `class_exists('GFAPI')`:

```php
if (!class_exists('GFAPI')) {
    require_once WP_PLUGIN_DIR . '/gravityforms/includes/api.php';
}
```

`GFAPI` is declared inside `api.php` itself (line 21), *below* that file's own guard (line 5). So the check can never answer "is Gravity Forms available", only "have I already loaded this one file".

Deactivating a plugin leaves its files on disk, so the `require_once` succeeds and `api.php` immediately hits:

```php
if ( ! class_exists( 'GFForms' ) ) { die(); }
```

A bare `die()` is not a PHP error. Nothing reaches `debug.log` (there is no error at any level to log), exit status stays `0`, and the response is a 200 with `Content-Length: 0`.

This fires on **every** request, because `OrgMan.php:177` registers `GravityFormsHelper::init` on `init`, and resolving that class name is what triggers the autoloader and executes the file.

### Why the existing guard did not prevent it

`init()` already checks correctly:

```php
if (!class_exists('GFForms')) {
    return;
}
```

But that guard is in a *method body*, while the fatal `require` is at *file scope*. File scope executes the instant the autoloader includes the class, so `init()` is never entered and its guard never runs. Merely referencing the class was already fatal.

### Why the require is removed rather than repaired

It could never do anything useful:

- **GF active**: GF already loaded `api.php` itself at `gravityforms.php:178`, so `GFAPI` exists and the branch is skipped. Dead code.
- **GF inactive**: the require is fatal.

Every path is either a no-op or a crash, so it goes.

(Aside on why GF's own guard passes for GF: `gravityforms.php` requires `api.php` at line 178 but declares `class GFForms` at line 246, *after* it. That works because the declaration is top-level and unconditional with no `extends`/`implements`, so PHP hoists it at compile time. The guard is correctly refusing standalone access from anywhere else.)

## Risk notes

Low. Comment-only replacement of a delete; no behavioural code changed.

The one remaining `GFAPI` reference, `\GFAPI::get_form()` in `get_form_html()`, stays safe. Its only caller is `src/WicketORM/templates-partials/supplemental-members.php:62`, which already gates on `class_exists('GFForms')` and renders a "Gravity Forms is not available" notice otherwise. So dropping the forced load does not expose a new "class not found" path.

Normal operation with GF active is unchanged, since the removed branch never executed in that state.

## Test evidence

Verified on a live site (WordPress 7.0.2, PHP 8.x, this plugin active) by changing one variable at a time:

| Gravity Forms | `GravityFormsHelper.php` | Homepage response |
|---|---|---|
| deactivated | before patch | `HTTP 200`, **0 bytes** (blank) |
| deactivated | after patch | `HTTP 200`, **159,734 bytes** (renders) |
| active | before patch | `HTTP 200`, 159,734 bytes |

Root cause was isolated by wrapping every `init` callback and logging entry/exit: execution entered `WicketORM\Helpers\GravityFormsHelper::init` and never returned, jumping straight to `shutdown`. `get_included_files()` at shutdown confirmed the final file loaded was `gravityforms/includes/api.php`.

`php -l` clean.

Not run: `composer check` (which is `cs:lint` alone). `php-cs-fixer` is a dev dependency and dev deps are not installed in the checkout used here, and I did not want to mutate `vendor/` to install it. The change adds only comments, so there is no code for the fixer to act on and no trailing whitespace was introduced. Worth letting CI confirm.

## Operational note

Recovery from this state is awkward and worth knowing about, because WP-CLI dies on the same code path. `wp plugin activate gravityforms` fails *silently* (no output, exit 0) while WordPress is unbootable. The working recovery is:

```
wp plugin activate gravityforms --skip-plugins=wicket-wp-account-centre
```

This matters for triage: deactivating plugins is a routine first step when chasing an unrelated bug, and the resulting failure is silent, total, and gives no diagnostic trail.
