### PR TITLE
refactor(rest): rename org-management/v1 namespace to wicket-acc/v1 #minor

### DIFF
--- a/src/WicketORM/Controllers/ApiController.php
+++ b/src/WicketORM/Controllers/ApiController.php
@@ -21,7 +21,7 @@ abstract class ApiController
      *
      * @var string
      */
-    protected $namespace = 'org-management/v1';
+    protected $namespace = 'wicket-acc/v1';
 
     /**
      * Register the routes for this controller.

--- a/src/WicketORM/Controllers/BusinessInfoController.php
+++ b/src/WicketORM/Controllers/BusinessInfoController.php
@@ -33,7 +33,7 @@ class BusinessInfoController extends ApiController
     public function __construct(BusinessInfoService $business_info_service)
     {
         $this->business_info_service = $business_info_service;
-        $this->namespace = 'org-management/v1/business';
+        $this->namespace = 'wicket-acc/v1/business';
     }
 
     /**

--- a/src/WicketORM/Controllers/DocumentController.php
+++ b/src/WicketORM/Controllers/DocumentController.php
@@ -33,7 +33,7 @@ class DocumentController extends ApiController
     public function __construct(DocumentService $document_service)
     {
         $this->document_service = $document_service;
-        $this->namespace = 'org-management/v1/documents';
+        $this->namespace = 'wicket-acc/v1/documents';
     }
 
     /**

--- a/src/WicketORM/Controllers/EngagementController.php
+++ b/src/WicketORM/Controllers/EngagementController.php
@@ -31,7 +31,7 @@ class EngagementController extends ApiController
     public function __construct(EngagementService $engagement_service)
     {
         $this->engagement_service = $engagement_service;
-        $this->namespace = 'org-management/v1/engagement';
+        $this->namespace = 'wicket-acc/v1/engagement';
     }
 
     /**

--- a/src/WicketORM/Controllers/MemberExportController.php
+++ b/src/WicketORM/Controllers/MemberExportController.php
@@ -31,7 +31,7 @@ class MemberExportController extends ApiController
     public function __construct(MemberExportService $export_service)
     {
         $this->export_service = $export_service;
-        $this->namespace = 'org-management/v1/exports';
+        $this->namespace = 'wicket-acc/v1/exports';
     }
 
     /**

--- a/src/WicketORM/Controllers/SubsidiaryController.php
+++ b/src/WicketORM/Controllers/SubsidiaryController.php
@@ -33,7 +33,7 @@ class SubsidiaryController extends ApiController
     public function __construct(SubsidiaryService $subsidiary_service)
     {
         $this->subsidiary_service = $subsidiary_service;
-        $this->namespace = 'org-management/v1/subsidiaries';
+        $this->namespace = 'wicket-acc/v1/subsidiaries';
     }
 
     /**

--- a/src/WicketORM/templates-partials/business-info.php
+++ b/src/WicketORM/templates-partials/business-info.php
@@ -62,7 +62,7 @@ if ($seat_limit_info) : ?>
 		<p><?php esc_html_e('Business information is not available for this organization.', 'wicket-acc'); ?></p>
 	<?php else : ?>
 	<form class="business-info__form"
-	      ds-post="<?php echo esc_url(rest_url('org-management/v1/business/info')); ?>"
+	      ds-post="<?php echo esc_url(rest_url('wicket-acc/v1/business/info')); ?>"
 	      ds-target="#business-info-container"
 	      ds-swap="innerHTML">
 		<input type="hidden" name="org_id" value="<?php echo esc_attr($org_id); ?>">

--- a/src/WicketORM/templates-partials/documents-list.php
+++ b/src/WicketORM/templates-partials/documents-list.php
@@ -34,7 +34,7 @@ $notice ??= null;
 
 	<div class="documents-toolbar wt_mb-4">
 		<form class="document-upload-form"
-		      ds-post="<?php echo esc_url(rest_url('org-management/v1/documents/upload')); ?>"
+		      ds-post="<?php echo esc_url(rest_url('wicket-acc/v1/documents/upload')); ?>"
 		      ds-target="#documents-list-container"
 		      ds-swap="innerHTML"
 		      enctype="multipart/form-data">
@@ -147,7 +147,7 @@ $notice ??= null;
 						</a>
 						|
 						<button
-							ds-delete="<?php echo esc_url(rest_url('org-management/v1/documents/delete/' . $document['id'] . '?org_id=' . $org_id . '&category=' . $category)); ?>"
+							ds-delete="<?php echo esc_url(rest_url('wicket-acc/v1/documents/delete/' . $document['id'] . '?org_id=' . $org_id . '&category=' . $category)); ?>"
 							ds-target="#documents-list-container"
 							ds-swap="innerHTML"
 							ds-confirm="<?php esc_attr_e('Are you sure you want to delete this document?', 'wicket-acc'); ?>"

--- a/src/WicketORM/templates-partials/engagement-summary.php
+++ b/src/WicketORM/templates-partials/engagement-summary.php
@@ -7,7 +7,7 @@
  * Loaded via EngagementController's REST endpoint; embed with Datastar data-on-load:
  *
  *   <div
- *     data-on-load="@get('<?php echo esc_url(rest_url('org-management/v1/engagement/person')); ?>?org_id=...')"
+ *     data-on-load="@get('<?php echo esc_url(rest_url('wicket-acc/v1/engagement/person')); ?>?org_id=...')"
  *   ></div>
  *
  * Variables provided by EngagementController::htmlResponse():

--- a/src/WicketORM/templates-partials/export-members-modal.php
+++ b/src/WicketORM/templates-partials/export-members-modal.php
@@ -30,7 +30,7 @@ $current_user = wp_get_current_user();
 $recipient_email = isset($recipient_email) ? sanitize_email((string) $recipient_email) : sanitize_email($current_user->user_email ?? '');
 $nonce = wp_create_nonce('wicket_orgman_export_' . $org_uuid);
 
-$export_url = rest_url('org-management/v1/exports/initiate');
+$export_url = rest_url('wicket-acc/v1/exports/initiate');
 $dialog_id = 'exportMembersDialog-' . $org_dom_suffix;
 $messages_id = 'export-messages-' . $org_dom_suffix;
 ?>

--- a/src/WicketORM/templates-partials/subsidiaries-list.php
+++ b/src/WicketORM/templates-partials/subsidiaries-list.php
@@ -159,7 +159,7 @@ function addSubsidiary(subsidiaryId, subsidiaryName) {
 		formData.append('_wpnonce', '<?php echo wp_create_nonce('org_management_subsidiary_add_' . $org_id); ?>');
 
 		// Send request via Datastar
-		Datastar.fetch('<?php echo esc_url(rest_url('org-management/v1/subsidiaries/add')); ?>', {
+		Datastar.fetch('<?php echo esc_url(rest_url('wicket-acc/v1/subsidiaries/add')); ?>', {
 			method: 'POST',
 			body: formData,
 			headers: {


### PR DESCRIPTION
## What
Renamed the internal WicketORM REST API namespace from `org-management/v1` to `wicket-acc/v1`.

## Why
`org-management/v1` did not conform to Wicket stack REST API naming conventions. Switching to `wicket-acc/v1` aligns Account Centre endpoints with `wicket-base/v1`, `wicket-aorm/v1`, and `wicket-gf/v1`.

## How
- Updated base controller `ApiController` and all child controllers (`SubsidiaryController`, `MemberExportController`, `DocumentController`, `EngagementController`, `BusinessInfoController`) to register routes under `wicket-acc/v1/...`.
- Updated all Datastar hypermedia template partials (`subsidiaries-list.php`, `business-info.php`, `engagement-summary.php`, `export-members-modal.php`, `documents-list.php`) to target the new `wicket-acc/v1` endpoints.

## Testing
- Verified route registration across controllers.
- Verified template `rest_url()` references match updated controller route definitions.
