### PR TITLE
fix: normalize MDP membership PATCH path with leading slash

### DIFF
--- a/src/WicketORM/Services/AdditionalSeatsService.php
+++ b/src/WicketORM/Services/AdditionalSeatsService.php
@@ -568,7 +568,7 @@ class AdditionalSeatsService
             ];
 
             $client = wicket_api_client();
-            $api_path = "organization_memberships/{$membership_id}";
+            $api_path = "/organization_memberships/{$membership_id}";
 
             try {
                 $response = $client->patch($api_path, ['json' => $payload]);


### PR DESCRIPTION
## What & why

`AdditionalSeatsService::updateMdpMembershipMaxAssignments()` built its MDP PATCH path without a leading slash (`"organization_memberships/{id}"`), while the sibling calls `getMembershipDataFromApi()` and `updateMdpSeatLimit()` use `"/organization_memberships/{id}"`.

The two forms are behaviorally identical today: the Wicket API client `base_uri` has an empty path, so RFC 3986 resolution yields the same absolute URL either way. This normalizes the path so a future `base_uri` change (for example a versioned prefix with a trailing slash) cannot silently route the tier-seat PATCH to the wrong endpoint.

Surfaced while diagnosing the ESCRS additional-seats flow (WWID-2115). The fulfilment code itself is correct and idempotent; the reported "no seats added" was a staging Stripe misconfiguration, not this path.

## Change
- `src/WicketORM/Services/AdditionalSeatsService.php`: add the leading slash to the membership PATCH path in `updateMdpMembershipMaxAssignments()`.

## Verification
- `php -l` clean; `composer cs:lint` clean (0 of 209 files).
- `wicket test unit:account-centre`: affected tests green (`AdditionalSeatsServiceTest`, `MultiTierAdditionalSeatsTest`). Two pre-existing, unrelated `MembershipRosterReaderTest` cache failures (reproduced on base without this change).
- End-to-end on a local staging copy: forcing `payment_complete` on the ESCRS tier-seat order bumped `max_assignments` 15 to 17 on the correct membership, with idempotent re-runs.

## Cross-repo coordination
The matching wicket-warden assertion lives in the `qa` repo on branch `fix/WWID-2115-normalize-mdp-api-path`. Merge that qa branch to `main` together with this PR so the suite stays green (the assertion now expects the leading slash).

Tracking: WWID-2115 / [Asana task](https://app.asana.com/1/1138832104141584/task/1217001170522018)