### PR TITLE
feat: profile image MDP field picker #minor (WWID-1911)

### DIFF
--- a/assets/js/wicket-acc-profile-image-mdp-fields.js
+++ b/assets/js/wicket-acc-profile-image-mdp-fields.js
@@ -1,0 +1,105 @@
+(function () {
+  'use strict';
+
+  /**
+   * Rebuild the profile-image MDP field <select> from a fresh grouped list.
+   *
+   * @param {HTMLSelectElement} select
+   * @param {Array} groups       Grouped field list from the REST response.
+   * @param {string}  keepValue  Previously selected composite ref to preserve.
+   */
+  function rebuildSelect(select, groups, keepValue) {
+    var noSyncingLabel = select.getAttribute('data-wicket-no-syncing-label') || 'No syncing';
+    keepValue = keepValue || '';
+
+    select.innerHTML = '';
+
+    var empty = document.createElement('option');
+    empty.value = '';
+    empty.textContent = noSyncingLabel;
+    if (keepValue === '') {
+      empty.selected = true;
+    }
+    select.appendChild(empty);
+
+    groups.forEach(function (group) {
+      var schemaSlug = group.schema_slug || '';
+      var schemaLabel = group.schema_label || schemaSlug;
+      var fields = group.fields || [];
+      if (!fields.length) {
+        return;
+      }
+
+      var optgroup = document.createElement('optgroup');
+      optgroup.label = schemaLabel;
+
+      fields.forEach(function (field) {
+        var option = document.createElement('option');
+        var ref = schemaSlug + '|' + (field.slug || '');
+        option.value = ref;
+        option.textContent = field.label || field.slug;
+        if (ref === keepValue) {
+          option.selected = true;
+        }
+        optgroup.appendChild(option);
+      });
+
+      select.appendChild(optgroup);
+    });
+  }
+
+  function init() {
+    var wrappers = document.querySelectorAll('[data-wicket-acc-mdp-fields]');
+
+    Array.prototype.forEach.call(wrappers, function (wrapper) {
+      var button = wrapper.querySelector('[data-wicket-acc-mdp-fields-refresh-button]');
+      var select = wrapper.querySelector('[data-wicket-acc-mdp-fields-select]');
+      if (!button || !select || button.dataset.bound) {
+        return;
+      }
+
+      button.dataset.bound = '1';
+
+      button.addEventListener('click', function () {
+        var url = button.getAttribute('data-rest-url');
+        var nonce = button.getAttribute('data-nonce');
+        var originalText = button.textContent;
+
+        button.disabled = true;
+        button.textContent = button.getAttribute('data-refreshing-label') || 'Refreshing...';
+
+        fetch(url, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'X-WP-Nonce': nonce,
+            'Content-Type': 'application/json'
+          }
+        })
+          .then(function (response) {
+            if (!response.ok) {
+              throw new Error('HTTP ' + response.status);
+            }
+            return response.json();
+          })
+          .then(function (data) {
+            var groups = data && Array.isArray(data.fields) ? data.fields : [];
+            rebuildSelect(select, groups, select.value);
+          })
+          .catch(function () {
+            window.alert(button.getAttribute('data-error-label') || 'Refresh failed.');
+          })
+          .finally(function () {
+            button.disabled = false;
+            button.textContent = originalText;
+          });
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/assets/js/wicket-acc-profile-image-mdp-fields.js
+++ b/assets/js/wicket-acc-profile-image-mdp-fields.js
@@ -54,19 +54,63 @@
     Array.prototype.forEach.call(wrappers, function (wrapper) {
       var button = wrapper.querySelector('[data-wicket-acc-mdp-fields-refresh-button]');
       var select = wrapper.querySelector('[data-wicket-acc-mdp-fields-select]');
-      if (!button || !select || button.dataset.bound) {
+      var spinner = wrapper.querySelector('[data-wicket-acc-mdp-fields-spinner]');
+      var status = wrapper.querySelector('[data-wicket-acc-mdp-fields-status]');
+      if (!button || !select || !status || button.dataset.bound) {
         return;
       }
 
       button.dataset.bound = '1';
 
+      var fadeTimer = null;
+      var hideTimer = null;
+
+      function clearStatusTimers() {
+        if (fadeTimer) { clearTimeout(fadeTimer); fadeTimer = null; }
+        if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
+      }
+
+      function hideStatus() {
+        clearStatusTimers();
+        status.style.display = 'none';
+        status.style.opacity = '1';
+        status.style.transition = '';
+      }
+
+      // Show a status line, then fade it out after 10 seconds.
+      function showStatus(message, isError) {
+        clearStatusTimers();
+        status.textContent = message;
+        status.style.transition = '';
+        status.style.opacity = '1';
+        status.style.display = 'inline-block';
+        status.style.color = isError ? '#d63638' : '#008a20';
+
+        fadeTimer = setTimeout(function () {
+          status.style.transition = 'opacity 1s ease';
+          status.style.opacity = '0';
+        }, 10000);
+
+        hideTimer = setTimeout(function () {
+          status.style.display = 'none';
+          status.style.transition = '';
+        }, 11000);
+      }
+
       button.addEventListener('click', function () {
         var url = button.getAttribute('data-rest-url');
         var nonce = button.getAttribute('data-nonce');
         var originalText = button.textContent;
+        var successLabel = button.getAttribute('data-success-label') || 'Field list refreshed.';
+        var errorLabel = button.getAttribute('data-error-label') || 'Refresh failed.';
 
         button.disabled = true;
         button.textContent = button.getAttribute('data-refreshing-label') || 'Refreshing...';
+        if (spinner) {
+          spinner.style.display = 'inline-block';
+          spinner.classList.add('is-active');
+        }
+        hideStatus();
 
         fetch(url, {
           method: 'POST',
@@ -85,13 +129,18 @@
           .then(function (data) {
             var groups = data && Array.isArray(data.fields) ? data.fields : [];
             rebuildSelect(select, groups, select.value);
+            showStatus(successLabel, false);
           })
           .catch(function () {
-            window.alert(button.getAttribute('data-error-label') || 'Refresh failed.');
+            showStatus(errorLabel, true);
           })
           .finally(function () {
             button.disabled = false;
             button.textContent = originalText;
+            if (spinner) {
+              spinner.classList.remove('is-active');
+              spinner.style.display = 'none';
+            }
           });
       });
     });

--- a/assets/js/wicket-acc-profile-image-mdp-fields.js
+++ b/assets/js/wicket-acc-profile-image-mdp-fields.js
@@ -103,6 +103,7 @@
         var originalText = button.textContent;
         var successLabel = button.getAttribute('data-success-label') || 'Field list refreshed.';
         var errorLabel = button.getAttribute('data-error-label') || 'Refresh failed.';
+        var emptyLabel = button.getAttribute('data-empty-label') || 'No MDP fields available.';
 
         button.disabled = true;
         button.textContent = button.getAttribute('data-refreshing-label') || 'Refreshing...';
@@ -127,8 +128,20 @@
             return response.json();
           })
           .then(function (data) {
-            var groups = data && Array.isArray(data.fields) ? data.fields : [];
-            rebuildSelect(select, groups, select.value);
+            // Distinguish three outcomes so a malformed or empty response never
+            // wipes the picker while reporting success.
+            //   - non-array data.fields -> malformed -> keep select, error.
+            //   - empty array           -> tenant has no fields -> keep select, warn.
+            //   - populated array       -> rebuild + success.
+            if (!data || !Array.isArray(data.fields)) {
+              showStatus(errorLabel, true);
+              return;
+            }
+            if (!data.fields.length) {
+              showStatus(emptyLabel, true);
+              return;
+            }
+            rebuildSelect(select, data.fields, select.value);
             showStatus(successLabel, false);
           })
           .catch(function () {

--- a/class-wicket-acc-main.php
+++ b/class-wicket-acc-main.php
@@ -446,6 +446,7 @@ class WicketAcc
         new Shortcodes();
         new Registers();
         new Assets();
+        new ProfileImageMdpFieldSettings();
 
         if (is_admin() || (defined("\WP_CLI") && \WP_CLI)) {
             new HFMigration(); // Migrate CF -> HF options before any HF read

--- a/docs/engineering/ac-profile-picture.md
+++ b/docs/engineering/ac-profile-picture.md
@@ -2,7 +2,7 @@
 title: "AC Profile Picture Block"
 audience: [developer, agent, implementer]
 php_class: WicketAcc\Blocks\ProfilePicture\init
-source_files: ["includes/blocks/ac-profile-picture/init.php", "includes/blocks/ac-profile-picture/render.php", "includes/blocks/ac-profile-picture/block.json", "src/Profile.php", "src/ProfilePictureFallback.php", "src/Helpers.php"]
+source_files: ["includes/blocks/ac-profile-picture/init.php", "includes/blocks/ac-profile-picture/render.php", "includes/blocks/ac-profile-picture/block.json", "src/Profile.php", "src/ProfilePictureFallback.php", "src/ProfileImageMdpFieldSettings.php", "src/Mdp/Schema.php", "src/Helpers.php"]
 ---
 
 # AC Profile Picture Block
@@ -35,7 +35,7 @@ The block reads the current picture from the MDP, with a deterministic fallback 
 2. ACF/option attachment lookup (`getAttachmentUrlFromOption`) — used when the MDP does not carry a profile picture.
 3. A 404 fallback returns the configured default URL when neither source resolves to a working image (`src/ProfilePictureFallback.php`).
 
-The profile picture schema is identified by slug (`profile-picture`), not by tenant UUID, so the same schema name works across every site (`src/Profile.php`, `src/CFInitOptions.php`).
+The profile picture schema is identified by slug (`profile-picture`), not by tenant UUID, so the same schema name works across every site (`src/Profile.php`, `src/InitOptions.php`).
 
 ### File Management
 
@@ -55,6 +55,49 @@ There is an explicit, fail-closed delete flow (`Wicket()->profile()->clear_profi
 
 The delete flow is wired into `docs/engineering/hooks.md` (`profile-image delete` action hook) so plugins or themes can react to a profile-picture removal.
 
+## MDP Profile Image Sync
+
+After a successful upload, the block writes the new image URL into one MDP
+additional_info field, so downstream systems (such as Higher Logic) can read it.
+The target field is configurable per site, because the field slug is not the
+same on every tenant (OBA uses `profprofile.memberphotourl`; others use
+`personal_info.photo_link`).
+
+### Setting
+
+A single ACC Option, `acc_profile_picture_mdp_field_ref` (stored in the
+`wicket_acc_options` array), holds a composite ref: `{schema_slug}|{field_slug}`.
+The default is empty, which means **No syncing**: the upload stays local to
+WordPress and the MDP call is skipped entirely (`Profile::syncProfileImageToMdp()`
+short-circuits and returns true).
+
+The setting renders as a grouped `<select>` in **ACC Options** (one optgroup per
+MDP widget schema, field slugs inside). The list is sourced dynamically from the
+tenant `json_schemas` endpoint (`WicketAcc\Mdp\Schema::getProfileImageFieldOptions()`),
+cached in a transient, and refreshed on demand by a **Refresh fields** button that
+calls `POST /wicket-acc/v1/profile-image-mdp-fields/refresh`.
+
+| | |
+|---|---|
+| Option key | `acc_profile_picture_mdp_field_ref` |
+| Storage | composite `{schema}\|{field}`, or empty for No syncing |
+| REST refresh | `POST /wicket-acc/v1/profile-image-mdp-fields/refresh` (`manage_options`) |
+| Owner class | `WicketAcc\ProfileImageMdpFieldSettings` |
+
+### Validation and drift
+
+The ref is validated at **settings-save time** only (`sanitizeField`), never on
+the upload path. If the selected field is later removed from the MDP, the
+previous value is kept (a warning is logged); the upload path reads the stored
+ref as a plain string and never queries schemas.
+
+### Migration
+
+A one-time migration (`ProfileImageMdpFieldSettings::maybeMigrateLegacyRef()`,
+guarded by the `wicket_acc_mdp_field_ref_migrated` flag) reads the legacy free-text
+pair `acc_profile_picture_mdp_schema` / `acc_profile_picture_mdp_field` and writes
+the composite ref. An empty legacy pair is a valid terminal state (No syncing).
+
 ### Form Handling
 
 - Secure nonce verification
@@ -64,6 +107,8 @@ The delete flow is wired into `docs/engineering/hooks.md` (`profile-image delete
 
 ## Recent Changes
 
+- Added the configurable MDP profile image field picker (ACC Option `acc_profile_picture_mdp_field_ref`). Default is No syncing (local only). Replaces the two legacy free-text slug options.
+- Migrated the legacy slug pair into the composite ref once on upgrade.
 - Identified the profile picture schema by slug instead of tenant-specific UUID.
 - Fixed default redirect and double-slash URL bugs in `src/Helpers.php` and `src/Profile.php`.
 - Added a 404 fallback path that returns the configured default when no file exists.

--- a/docs/engineering/ac-profile-picture.md
+++ b/docs/engineering/ac-profile-picture.md
@@ -86,10 +86,23 @@ calls `POST /wicket-acc/v1/profile-image-mdp-fields/refresh`.
 
 ### Validation and drift
 
-The ref is validated at **settings-save time** only (`sanitizeField`), never on
-the upload path. If the selected field is later removed from the MDP, the
-previous value is kept (a warning is logged); the upload path reads the stored
-ref as a plain string and never queries schemas.
+Drift (the configured field is later removed from the MDP) is handled at two
+times, plus a visible admin notice. All three agree on one trust rule: an empty
+field list gives no signal, so it never blocks a sync or raises a false alarm.
+
+- **Settings-save time** (`ProfileImageMdpFieldSettings::sanitizeField`). The ref
+  is validated against the live list. On drift, the previous value is kept and a
+  warning is logged. Never runs on the upload path.
+- **Upload time** (`Profile::syncProfileImageToMdp` calls
+  `ProfileImageMdpFieldSettings::configuredRefHasDrifted()`). Before the MDP write,
+  the stored ref is checked against the raw transient only. If the cache is
+  populated and the ref is absent, the write is skipped (degrade to No syncing)
+  and a warning is logged, so a removed field is not retried on every upload. An
+  empty/absent cache gives no signal: the check never calls MDP and the upload
+  path stays MDP-free.
+- **Settings UI** (`ProfileImageMdpFieldSettings::renderField`). When the stored
+  ref is not in a populated live list, a red notice tells the operator to pick a
+  valid field or set No syncing.
 
 ### Migration
 

--- a/src/InitOptions.php
+++ b/src/InitOptions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WicketAcc;
 
+use HyperFields\CustomField;
 use HyperFields\Field;
 use HyperFields\HyperFields;
 
@@ -112,15 +113,10 @@ class InitOptions extends WicketAcc
         );
 
         $section->addField(
-            Field::make('text', 'acc_profile_picture_mdp_schema', __('Profile picture MDP schema slug', 'wicket-acc'))
-                ->setHelp(__('MDP schema slug that contains the profile picture field. Stable across tenants. Leave blank to use the plugin default.', 'wicket-acc'))
-                ->setPlaceholder(Profile::PROFILE_IMAGE_SCHEMA_SLUG_DEFAULT)
-        );
-
-        $section->addField(
-            Field::make('text', 'acc_profile_picture_mdp_field', __('Profile picture MDP field slug', 'wicket-acc'))
-                ->setHelp(__('Field slug within the schema above that stores the profile picture URL. Leave blank to use the plugin default.', 'wicket-acc'))
-                ->setPlaceholder(Profile::PROFILE_IMAGE_FIELD_SLUG_DEFAULT)
+            CustomField::build(ProfileImageMdpFieldSettings::OPTION_KEY, __('Profile image MDP field', 'wicket-acc'))
+                ->setRenderCallback([ProfileImageMdpFieldSettings::class, 'renderField'])
+                ->setSanitizeCallback([ProfileImageMdpFieldSettings::class, 'sanitizeField'])
+                ->setAssets([WICKET_ACC_URL . 'assets/js/wicket-acc-profile-image-mdp-fields.js'])
         );
 
         $section->addField(

--- a/src/Mdp/Schema.php
+++ b/src/Mdp/Schema.php
@@ -195,4 +195,287 @@ class Schema extends Init
 
         return $this->getSchemaOptions($targetSchema, $field, $subField);
     }
+
+    /**
+     * Transient key for the cached profile-image MDP field list.
+     */
+    public const PROFILE_IMAGE_FIELDS_TRANSIENT = 'wicket_acc_mdp_profile_image_fields';
+
+    /**
+     * List every additional_info widget schema and its storable sub-fields,
+     * grouped for a select dropdown.
+     *
+     * Source is getSchemas() (the tenant json_schemas endpoint). The list is
+     * tenant-wide and does not depend on any one person record.
+     *
+     * Used by the Account Centre profile-picture setting so the Implementation
+     * Specialist can pick which MDP additional_info field stores the uploaded
+     * image URL.
+     *
+     * @return array<int, array{schema_slug: string, schema_label: string, fields: array<int, array{slug: string, label: string}>}>
+     *     Empty array when no schemas or no storable fields are found.
+     */
+    public function getProfileImageFieldOptions(): array
+    {
+        $schemas = $this->getSchemas();
+        if (!is_array($schemas) || empty($schemas)) {
+            return [];
+        }
+
+        return self::buildProfileImageFieldOptions($schemas, $this->currentLanguage());
+    }
+
+    /**
+     * Cached profile-image MDP field options, transient-backed.
+     *
+     * Wraps getProfileImageFieldOptions() with a WordPress transient so the
+     * settings UI and refresh route do not hit MDP on every render.
+     *
+     * @param int $ttl Cache lifetime in seconds. Default 6 hours.
+     *
+     * @return array Grouped options (see getProfileImageFieldOptions()).
+     */
+    public function getCachedProfileImageFieldOptions(int $ttl = 21600): array
+    {
+        $cached = get_transient(self::PROFILE_IMAGE_FIELDS_TRANSIENT);
+        if (is_array($cached)) {
+            return $cached;
+        }
+
+        $options = $this->getProfileImageFieldOptions();
+        set_transient(self::PROFILE_IMAGE_FIELDS_TRANSIENT, $options, $ttl);
+
+        return $options;
+    }
+
+    /**
+     * Drop the cached field list and refetch once. Returns the fresh list.
+     *
+     * Called by the Refresh button REST route. Re-seeds the transient.
+     *
+     * @return array
+     */
+    public function refreshProfileImageFieldOptions(): array
+    {
+        delete_transient(self::PROFILE_IMAGE_FIELDS_TRANSIENT);
+
+        return $this->getCachedProfileImageFieldOptions();
+    }
+
+    /**
+     * Pure extractor: turn raw json_schemas data into a grouped field list.
+     *
+     * Separated from getProfileImageFieldOptions() so it is unit-testable with a
+     * fixture array and no MDP I/O. Walks both flat properties and oneOf
+     * branches. Keeps only scalar fields that can store a single URL string.
+     *
+     * @param array  $schemas  Raw return of getSchemas() (array of schema resources, or a JSON:API {data:[...]} wrapper).
+     * @param string $language ISO 639-1 code used to resolve ui_schema i18n labels (e.g. "en").
+     *
+     * @return array<int, array{schema_slug: string, schema_label: string, fields: array<int, array{slug: string, label: string}>}>
+     */
+    public static function buildProfileImageFieldOptions(array $schemas, string $language): array
+    {
+        $resources = self::normalizeSchemaResources($schemas);
+        $grouped = [];
+
+        foreach ($resources as $schema) {
+            $attributes = $schema['attributes'] ?? [];
+            if (!is_array($attributes)) {
+                continue;
+            }
+
+            $schema_slug = isset($attributes['key']) && is_string($attributes['key']) ? $attributes['key'] : '';
+            if ($schema_slug === '') {
+                continue;
+            }
+
+            $json_schema = $attributes['schema'] ?? [];
+            $ui_schema = isset($attributes['ui_schema']) && is_array($attributes['ui_schema']) ? $attributes['ui_schema'] : [];
+            if (!is_array($json_schema)) {
+                continue;
+            }
+
+            $fields = self::extractStorableStringFields($json_schema, $ui_schema, $language);
+            if (empty($fields)) {
+                continue;
+            }
+
+            $grouped[] = [
+                'schema_slug'  => $schema_slug,
+                'schema_label' => self::resolveSchemaLabel($attributes, $schema_slug),
+                'fields'       => $fields,
+            ];
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * Normalize raw getSchemas() output into a flat list of resource arrays.
+     *
+     * Accepts either a JSON:API collection wrapper ({data:[resource,...]}) or an
+     * already-flat list of resources. Drops entries that are not resources.
+     *
+     * @param array $schemas
+     *
+     * @return array<int, array>
+     */
+    private static function normalizeSchemaResources(array $schemas): array
+    {
+        $list = isset($schemas['data']) && is_array($schemas['data']) ? $schemas['data'] : $schemas;
+
+        $resources = [];
+        foreach ($list as $item) {
+            if (is_array($item) && isset($item['attributes'])) {
+                $resources[] = $item;
+            }
+        }
+
+        return $resources;
+    }
+
+    /**
+     * Collect scalar, URL-capable sub-fields from a widget JSON schema.
+     *
+     * Merges properties from flat `properties` and from each `oneOf` branch
+     * (polymorphic widgets). Excludes composite field shapes (repeaters,
+     * objects) that cannot store a single URL string. De-duplicates by slug.
+     *
+     * @param array  $json_schema
+     * @param array  $ui_schema
+     * @param string $language
+     *
+     * @return array<int, array{slug: string, label: string}>
+     */
+    private static function extractStorableStringFields(array $json_schema, array $ui_schema, string $language): array
+    {
+        $property_sets = [];
+        if (isset($json_schema['properties']) && is_array($json_schema['properties'])) {
+            $property_sets[] = $json_schema['properties'];
+        }
+        if (isset($json_schema['oneOf']) && is_array($json_schema['oneOf'])) {
+            foreach ($json_schema['oneOf'] as $branch) {
+                if (is_array($branch) && isset($branch['properties']) && is_array($branch['properties'])) {
+                    $property_sets[] = $branch['properties'];
+                }
+            }
+        }
+
+        $fields = [];
+        $seen = [];
+        foreach ($property_sets as $properties) {
+            foreach ($properties as $slug => $definition) {
+                if (!is_string($slug) || isset($seen[$slug])) {
+                    continue;
+                }
+                if (!is_array($definition) || !self::isStorableScalarField($definition)) {
+                    continue;
+                }
+
+                $seen[$slug] = true;
+                $fields[] = [
+                    'slug'  => $slug,
+                    'label' => self::resolveFieldLabel($slug, $definition, $ui_schema, $language),
+                ];
+            }
+        }
+
+        usort($fields, static fn (array $a, array $b): int => strcasecmp($a['label'], $b['label']));
+
+        return $fields;
+    }
+
+    /**
+     * Decide whether a JSON schema property can store a single URL string.
+     *
+     * Excludes composite shapes (items, nested properties, oneOf/allOf) and
+     * non-string scalar types. An untyped scalar with no composite keys is
+     * treated as a candidate (MDP sometimes omits type on string fields).
+     *
+     * @param array $property
+     *
+     * @return bool
+     */
+    private static function isStorableScalarField(array $property): bool
+    {
+        if (isset($property['items']) || isset($property['properties']) || isset($property['oneOf']) || isset($property['allOf'])) {
+            return false;
+        }
+
+        $type = $property['type'] ?? null;
+        if ($type === 'string') {
+            return true;
+        }
+        if (isset($property['format']) && is_string($property['format']) && strtolower($property['format']) === 'url') {
+            return true;
+        }
+
+        return $type === null;
+    }
+
+    /**
+     * Resolve a human label for a sub-field, preferring UI i18n, then the JSON
+     * schema title, then the slug itself.
+     *
+     * @param string $slug
+     * @param array  $property
+     * @param array  $ui_schema
+     * @param string $language
+     *
+     * @return string
+     */
+    private static function resolveFieldLabel(string $slug, array $property, array $ui_schema, string $language): string
+    {
+        $ui = $ui_schema[$slug] ?? null;
+        if (is_array($ui)) {
+            $i18n_title = $ui['ui:i18n']['title'][$language] ?? null;
+            if (is_string($i18n_title) && trim($i18n_title) !== '') {
+                return trim($i18n_title);
+            }
+            $ui_title = $ui['ui:title'] ?? null;
+            if (is_string($ui_title) && trim($ui_title) !== '') {
+                return trim($ui_title);
+            }
+        }
+
+        $title = $property['title'] ?? null;
+        if (is_string($title) && trim($title) !== '') {
+            return trim($title);
+        }
+
+        return $slug;
+    }
+
+    /**
+     * Resolve a human label for a widget schema, falling back to its slug.
+     *
+     * @param array  $attributes
+     * @param string $fallback
+     *
+     * @return string
+     */
+    private static function resolveSchemaLabel(array $attributes, string $fallback): string
+    {
+        foreach (['name', 'title', 'label'] as $key) {
+            $value = $attributes[$key] ?? null;
+            if (is_string($value) && trim($value) !== '') {
+                return trim($value);
+            }
+        }
+
+        return $fallback;
+    }
+
+    /**
+     * Current site language as an ISO 639-1 code (e.g. "en", "fr").
+     *
+     * @return string
+     */
+    private function currentLanguage(): string
+    {
+        $code = strtok((string) get_bloginfo('language'), '-');
+
+        return is_string($code) && $code !== '' ? $code : 'en';
+    }
 }

--- a/src/Mdp/Schema.php
+++ b/src/Mdp/Schema.php
@@ -403,6 +403,11 @@ class Schema extends Init
             return false;
         }
 
+        // Enum fields accept only their listed values, never an arbitrary URL.
+        if (isset($property['enum'])) {
+            return false;
+        }
+
         $type = $property['type'] ?? null;
         if ($type === 'string') {
             return true;

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -13,27 +13,6 @@ defined('ABSPATH') || exit;
 class Profile extends WicketAcc
 {
     /**
-     * Default MDP schema slug that holds the profile image (photo_link) field.
-     *
-     * MDP schema UUIDs are tenant-specific, but the slug is stable across tenants,
-     * so we identify the schema by slug. Used as the fallback when the "Profile
-     * picture MDP schema" ACC Option is left blank.
-     *
-     * @var string
-     */
-    public const PROFILE_IMAGE_SCHEMA_SLUG_DEFAULT = 'personal_info';
-
-    /**
-     * Default field key (slug) within the schema that stores the profile image URL.
-     *
-     * The field slug is not guaranteed to be "photo_link" on every tenant, so it
-     * is configurable; this is the fallback when the ACC Option is left blank.
-     *
-     * @var string
-     */
-    public const PROFILE_IMAGE_FIELD_SLUG_DEFAULT = 'photo_link';
-
-    /**
      * Constructor.
      */
     public function __construct(
@@ -264,6 +243,13 @@ class Profile extends WicketAcc
      */
     public function syncProfileImageToMdp(?string $profile_image_url = null): bool
     {
+        // No syncing configured: keep the image local. Do not call MDP.
+        $ref = $this->getProfileImageFieldRef();
+        if ($ref === null) {
+            return true;
+        }
+        [$schema_slug, $field_slug] = $ref;
+
         $person_uuid = WACC()->Mdp()->Person()->getCurrentPersonUuid();
         if (empty($person_uuid)) {
             WACC()->Log()->warning('Unable to sync profile image to MDP: current person UUID is missing.', [
@@ -274,13 +260,12 @@ class Profile extends WicketAcc
         }
 
         $photo_link = $this->normalizeProfileImageUrlForMdp($profile_image_url);
-        $schema_slug = $this->getProfileImageSchemaSlug();
-        $fields_to_update = $this->buildProfileImageDataFieldsPayload($person_uuid, $schema_slug, $photo_link);
+        $fields_to_update = $this->buildProfileImageDataFieldsPayload($person_uuid, $schema_slug, $field_slug, $photo_link);
         $result = WACC()->Mdp()->Person()->updatePerson($person_uuid, $fields_to_update);
 
         // Retry once on version conflict after refetching latest data_fields/version.
         if (empty($result['success']) && $this->isRecordConflictResponse($result)) {
-            $fields_to_update = $this->buildProfileImageDataFieldsPayload($person_uuid, $schema_slug, $photo_link);
+            $fields_to_update = $this->buildProfileImageDataFieldsPayload($person_uuid, $schema_slug, $field_slug, $photo_link);
             $result = WACC()->Mdp()->Person()->updatePerson($person_uuid, $fields_to_update);
         }
 
@@ -306,6 +291,22 @@ class Profile extends WicketAcc
     public function clearProfileImageFromMdp(): bool
     {
         return $this->syncProfileImageToMdp(null);
+    }
+
+    /**
+     * Resolve the configured profile-image MDP field ref.
+     *
+     * Reads the composite option (acc_profile_picture_mdp_field_ref) and parses
+     * it into [schema_slug, field_slug]. Returns null for "No syncing" or a
+     * malformed value, which short-circuits the sync.
+     *
+     * @return array{0: string, 1: string}|null
+     */
+    private function getProfileImageFieldRef(): ?array
+    {
+        $raw = WACC()->getOption(ProfileImageMdpFieldSettings::OPTION_KEY, ProfileImageMdpFieldSettings::NO_SYNCING);
+
+        return ProfileImageMdpFieldSettings::parseFieldRef(is_string($raw) ? $raw : null);
     }
 
     /**
@@ -481,7 +482,7 @@ class Profile extends WicketAcc
      *
      * @return array
      */
-    private function buildProfileImageDataFieldsPayload(string $person_uuid, string $schema_slug, ?string $photo_link): array
+    private function buildProfileImageDataFieldsPayload(string $person_uuid, string $schema_slug, string $field_slug, ?string $photo_link): array
     {
         $current_person = WACC()->Mdp()->Person()->getPersonByUuid($person_uuid);
         $current_data_fields = $this->extractPersonDataFields($current_person);
@@ -512,7 +513,6 @@ class Profile extends WicketAcc
         // Match MDP UI behavior: remove the key on delete, set full URL on update.
         // Sibling fields in $data_field_value are carried through unchanged.
         // The photo field is format:url in MDP, so it must be unset (not "") on delete.
-        $field_slug = $this->getProfileImageFieldSlug();
         if ($photo_link === null) {
             unset($data_field_value[$field_slug]);
         } else {
@@ -655,41 +655,6 @@ class Profile extends WicketAcc
     }
 
     /**
-     * Resolve the MDP schema slug that stores the profile image (photo_link).
-     *
-     * Reads the "Profile picture MDP schema slug" ACC Option, falling back to
-     * PROFILE_IMAGE_SCHEMA_SLUG_DEFAULT when unset or blank. The slug is stable
-     * across tenants (unlike the schema UUID), so no runtime schema lookup is
-     * needed.
-     *
-     * @return string
-     */
-    private function getProfileImageSchemaSlug(): string
-    {
-        $configured = WACC()->getOption('acc_profile_picture_mdp_schema', '');
-        $configured = is_string($configured) ? trim($configured) : '';
-
-        return $configured !== '' ? $configured : self::PROFILE_IMAGE_SCHEMA_SLUG_DEFAULT;
-    }
-
-    /**
-     * Resolve the MDP field slug (within the schema) that stores the profile image URL.
-     *
-     * Reads the "Profile picture MDP field slug" ACC Option, falling back to
-     * PROFILE_IMAGE_FIELD_SLUG_DEFAULT when unset or blank. The field is not
-     * guaranteed to be "photo_link" on every tenant, so it must be configurable.
-     *
-     * @return string
-     */
-    private function getProfileImageFieldSlug(): string
-    {
-        $configured = WACC()->getOption('acc_profile_picture_mdp_field', '');
-        $configured = is_string($configured) ? trim($configured) : '';
-
-        return $configured !== '' ? $configured : self::PROFILE_IMAGE_FIELD_SLUG_DEFAULT;
-    }
-
-    /**
      * Determine whether MDP data_fields currently contain a profile image photo_link.
      *
      * @param array $data_fields
@@ -698,7 +663,13 @@ class Profile extends WicketAcc
      */
     private function hasProfileImagePhotoLink(array $data_fields): bool
     {
-        $data_field = $this->findDataFieldBySchemaSlug($data_fields, $this->getProfileImageSchemaSlug());
+        $ref = $this->getProfileImageFieldRef();
+        if ($ref === null) {
+            return false;
+        }
+        [$schema_slug, $field_slug] = $ref;
+
+        $data_field = $this->findDataFieldBySchemaSlug($data_fields, $schema_slug);
         if (!is_array($data_field)) {
             return false;
         }
@@ -711,7 +682,7 @@ class Profile extends WicketAcc
             return false;
         }
 
-        $photo_link = $value[$this->getProfileImageFieldSlug()] ?? null;
+        $photo_link = $value[$field_slug] ?? null;
 
         return is_string($photo_link) && trim($photo_link) !== '';
     }

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -248,6 +248,19 @@ class Profile extends WicketAcc
         if ($ref === null) {
             return true;
         }
+
+        // Drift guard: if the cached field list is populated and the configured
+        // ref is no longer in it, the field was removed from the MDP. Skip the
+        // write (degrade to No syncing) so we do not fail on every upload. The
+        // check reads the raw transient only and never calls MDP.
+        if (ProfileImageMdpFieldSettings::configuredRefHasDrifted()) {
+            WACC()->Log()->warning('Profile image MDP field ref no longer in the cached schema list; skipping sync. Update the Account Centre "Profile image MDP field" setting.', [
+                'source' => __CLASS__,
+            ]);
+
+            return true;
+        }
+
         [$schema_slug, $field_slug] = $ref;
 
         $person_uuid = WACC()->Mdp()->Person()->getCurrentPersonUuid();

--- a/src/ProfileImageMdpFieldSettings.php
+++ b/src/ProfileImageMdpFieldSettings.php
@@ -225,7 +225,13 @@ class ProfileImageMdpFieldSettings extends WicketAcc
         $refreshing_label = __('Refreshing...', 'wicket-acc');
         $success_label = __('Field list refreshed.', 'wicket-acc');
         $error_label = __('Could not refresh the field list. Check the MDP connection and try again.', 'wicket-acc');
+        $empty_label = __('No MDP fields are available for this tenant.', 'wicket-acc');
         $help = __('Choose which MDP additional-info field stores the uploaded profile image URL. "No syncing" keeps the image in WordPress only.', 'wicket-acc');
+
+        // Drift flag: the stored ref is no longer in a populated (trustworthy)
+        // cached field list. An empty list gives no signal (MDP may just be
+        // unreachable), so we do not cry wolf in that case.
+        $drifted = self::storedRefHasDrifted($value, $options);
         ?>
         <div class="hyperpress-field-wrapper">
             <div class="hyperpress-field-row">
@@ -272,11 +278,18 @@ class ProfileImageMdpFieldSettings extends WicketAcc
                             data-nonce="<?php echo esc_attr($nonce); ?>"
                             data-refreshing-label="<?php echo esc_attr($refreshing_label); ?>"
                             data-success-label="<?php echo esc_attr($success_label); ?>"
-                            data-error-label="<?php echo esc_attr($error_label); ?>">
+                            data-error-label="<?php echo esc_attr($error_label); ?>"
+                            data-empty-label="<?php echo esc_attr($empty_label); ?>">
                         <?php echo esc_html($refresh_label); ?>
                     </button>
                     <span class="spinner" style="float:none; display:none;" data-wicket-acc-mdp-fields-spinner></span>
                     <span class="description" data-wicket-acc-mdp-fields-status style="display:none;"></span>
+
+                    <?php if ($drifted) : ?>
+                        <p class="description" style="color:#d63638;">
+                            <?php echo esc_html(__('The selected field no longer exists in the MDP schema. Pick a valid field, or set "No syncing". Until then, uploads stay local and are not sent to the MDP.', 'wicket-acc')); ?>
+                        </p>
+                    <?php endif; ?>
 
                     <p class="description"><?php echo esc_html($help); ?></p>
                 </div>
@@ -327,7 +340,27 @@ class ProfileImageMdpFieldSettings extends WicketAcc
      */
     private static function refExistsInLiveList(string $schema_slug, string $field_slug): bool
     {
-        foreach (WACC()->Mdp()->Schema()->getCachedProfileImageFieldOptions() as $group) {
+        return self::refInGroupedList(
+            $schema_slug,
+            $field_slug,
+            WACC()->Mdp()->Schema()->getCachedProfileImageFieldOptions()
+        );
+    }
+
+    /**
+     * Pure membership check: is a schema|field pair present in a grouped list?
+     *
+     * Shared by the save-time check (refExistsInLiveList), the settings UI
+     * drift notice (storedRefHasDrifted), and the upload-path guard
+     * (configuredRefHasDrifted) so all three agree on what "in the list" means.
+     *
+     * @param string $schema_slug
+     * @param string $field_slug
+     * @param array  $list        Grouped options (schema_slug/schema_label/fields).
+     */
+    private static function refInGroupedList(string $schema_slug, string $field_slug, array $list): bool
+    {
+        foreach ($list as $group) {
             if (($group['schema_slug'] ?? '') !== $schema_slug) {
                 continue;
             }
@@ -339,6 +372,49 @@ class ProfileImageMdpFieldSettings extends WicketAcc
         }
 
         return false;
+    }
+
+    /**
+     * Whether a given ref value has drifted out of a supplied (populated) list.
+     *
+     * Used by the settings UI. An empty list gives no signal (the MDP may be
+     * unreachable), so it returns false to avoid a false alarm.
+     *
+     * @param string $value   Stored composite ref (raw option value).
+     * @param array  $options Grouped field list already fetched for rendering.
+     */
+    private static function storedRefHasDrifted(string $value, array $options): bool
+    {
+        if ($value === '' || $options === []) {
+            return false;
+        }
+
+        $parsed = self::parseFieldRef($value);
+        if ($parsed === null) {
+            return true;
+        }
+
+        return !self::refInGroupedList($parsed[0], $parsed[1], $options);
+    }
+
+    /**
+     * Whether the stored ref has drifted out of a populated (trustworthy) cache.
+     *
+     * Upload-path guard. Reads the raw transient only: an empty/absent cache
+     * gives no drift signal, so this check never triggers an MDP schemas call
+     * and the upload path stays MDP-free in the worst case. When the cache is
+     * populated and the stored ref is absent, the configured field has been
+     * removed from the MDP and the caller should skip the write (degrade to
+     * No syncing) instead of failing on every upload.
+     */
+    public static function configuredRefHasDrifted(): bool
+    {
+        $cached = get_transient(Mdp\Schema::PROFILE_IMAGE_FIELDS_TRANSIENT);
+        if (!is_array($cached) || $cached === []) {
+            return false;
+        }
+
+        return self::storedRefHasDrifted(self::currentStoredRef(), $cached);
     }
 
     /**

--- a/src/ProfileImageMdpFieldSettings.php
+++ b/src/ProfileImageMdpFieldSettings.php
@@ -223,6 +223,7 @@ class ProfileImageMdpFieldSettings extends WicketAcc
         $no_syncing_label = __('No syncing (keep image local)', 'wicket-acc');
         $refresh_label = __('Refresh fields', 'wicket-acc');
         $refreshing_label = __('Refreshing...', 'wicket-acc');
+        $success_label = __('Field list refreshed.', 'wicket-acc');
         $error_label = __('Could not refresh the field list. Check the MDP connection and try again.', 'wicket-acc');
         $help = __('Choose which MDP additional-info field stores the uploaded profile image URL. "No syncing" keeps the image in WordPress only.', 'wicket-acc');
         ?>
@@ -264,14 +265,18 @@ class ProfileImageMdpFieldSettings extends WicketAcc
                     </select>
 
                     <button type="button"
-                            class="button"
+                            class="button-link"
+                            style="display:inline-block; width:auto;"
                             data-wicket-acc-mdp-fields-refresh-button
                             data-rest-url="<?php echo esc_url($rest_url); ?>"
                             data-nonce="<?php echo esc_attr($nonce); ?>"
                             data-refreshing-label="<?php echo esc_attr($refreshing_label); ?>"
+                            data-success-label="<?php echo esc_attr($success_label); ?>"
                             data-error-label="<?php echo esc_attr($error_label); ?>">
                         <?php echo esc_html($refresh_label); ?>
                     </button>
+                    <span class="spinner" style="float:none; display:none;" data-wicket-acc-mdp-fields-spinner></span>
+                    <span class="description" data-wicket-acc-mdp-fields-status style="display:none;"></span>
 
                     <p class="description"><?php echo esc_html($help); ?></p>
                 </div>

--- a/src/ProfileImageMdpFieldSettings.php
+++ b/src/ProfileImageMdpFieldSettings.php
@@ -1,0 +1,348 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WicketAcc;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+// No direct access
+defined('ABSPATH') || exit;
+
+/**
+ * Profile image -> MDP additional-info field picker.
+ *
+ * Owns the settings concern for choosing which MDP additional_info field stores
+ * the uploaded profile image URL. Hosts:
+ *   - the option key and the composite ref format ("{schema_slug}|{field_slug}");
+ *   - the refresh REST route (POST /wicket-acc/v1/profile-image-mdp-fields/refresh);
+ *   - shared ref parse/format helpers used by Profile.php, the settings UI, and
+ *     the one-time migration.
+ *
+ * The field enumerator itself lives on WicketAcc\Mdp\Schema::getProfileImageFieldOptions().
+ * This class is instantiated unconditionally so its rest_api_init hook fires
+ * during REST requests (which are not is_admin).
+ */
+class ProfileImageMdpFieldSettings extends WicketAcc
+{
+    /** Option key storing the composite ref, or empty for "No syncing". */
+    public const OPTION_KEY = 'acc_profile_picture_mdp_field_ref';
+
+    /** One-time migration guard flag. */
+    public const MIGRATION_FLAG = 'wicket_acc_mdp_field_ref_migrated';
+
+    public const REST_NAMESPACE = 'wicket-acc/v1';
+
+    public const REST_ROUTE = '/profile-image-mdp-fields/refresh';
+
+    /** Sentinel value meaning "do not sync" (empty string). */
+    public const NO_SYNCING = '';
+
+    /**
+     * Constructor. Hooks the refresh REST route on every request context.
+     */
+    public function __construct()
+    {
+        add_action('rest_api_init', [$this, 'registerRoutes']);
+        // Run after HFMigration (admin_init priority 5) so legacy keys are in the
+        // HyperFields option array before we read them.
+        add_action('admin_init', [$this, 'maybeMigrateLegacyRef'], 10);
+        if (defined('\WP_CLI') && \WP_CLI) {
+            // CLI has no admin_init; run on init so a first CLI request migrates.
+            add_action('init', [$this, 'maybeMigrateLegacyRef'], 20);
+        }
+    }
+
+    /**
+     * Register REST routes.
+     */
+    public function registerRoutes(): void
+    {
+        register_rest_route(self::REST_NAMESPACE, self::REST_ROUTE, [
+            [
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => [$this, 'handleRefresh'],
+                'permission_callback' => static fn (): bool => current_user_can('manage_options'),
+            ],
+        ]);
+    }
+
+    /**
+     * Refresh the cached MDP field list and return the fresh grouped options.
+     *
+     * Called by the settings page Refresh button. Clears the transient, refetches
+     * once from the tenant json_schemas endpoint, and re-seeds the cache.
+     *
+     * @param WP_REST_Request $request
+     *
+     * @return WP_REST_Response
+     */
+    public function handleRefresh(WP_REST_Request $request): WP_REST_Response
+    {
+        $options = WACC()->Mdp()->Schema()->refreshProfileImageFieldOptions();
+
+        return new WP_REST_Response([
+            'success' => true,
+            'fields'  => $options,
+        ], 200);
+    }
+
+    /**
+     * Parse a stored composite ref into [schema_slug, field_slug].
+     *
+     * @param string|null $ref Raw option value.
+     *
+     * @return array{0: string, 1: string}|null Null when empty (No syncing) or malformed.
+     */
+    public static function parseFieldRef(?string $ref): ?array
+    {
+        if ($ref === null) {
+            return null;
+        }
+
+        $ref = trim($ref);
+        if ($ref === '' || !str_contains($ref, '|')) {
+            return null;
+        }
+
+        [$schema, $field] = explode('|', $ref, 2);
+        $schema = trim($schema);
+        $field = trim($field);
+        if ($schema === '' || $field === '') {
+            return null;
+        }
+
+        return [$schema, $field];
+    }
+
+    /**
+     * Build a composite ref from a schema and field slug.
+     *
+     * @param string $schema_slug
+     * @param string $field_slug
+     *
+     * @return string
+     */
+    public static function formatFieldRef(string $schema_slug, string $field_slug): string
+    {
+        return $schema_slug . '|' . $field_slug;
+    }
+
+    /**
+     * One-time migration of the legacy free-text slug pair into the composite ref.
+     *
+     * Reads the old acc_profile_picture_mdp_schema / acc_profile_picture_mdp_field
+     * options and writes acc_profile_picture_mdp_field_ref. Guarded by a flag so
+     * it runs once. Runs on admin_init (after the Carbon->HyperFields migration)
+     * and on the WP_CLI init hook. An empty legacy pair is a valid terminal state
+     * (No syncing default) and still sets the flag.
+     */
+    public function maybeMigrateLegacyRef(): void
+    {
+        if (get_option(self::MIGRATION_FLAG)) {
+            return;
+        }
+
+        $existing = WACC()->getOption(self::OPTION_KEY, self::NO_SYNCING);
+        if (is_string($existing) && $existing !== self::NO_SYNCING) {
+            // Already configured manually (or migrated); just mark done.
+            update_option(self::MIGRATION_FLAG, true);
+
+            return;
+        }
+
+        $legacy_schema = $this->readLegacyOption('acc_profile_picture_mdp_schema');
+        $legacy_field = $this->readLegacyOption('acc_profile_picture_mdp_field');
+
+        if ($legacy_schema !== '' && $legacy_field !== '') {
+            $this->writeMainOption(self::OPTION_KEY, self::formatFieldRef($legacy_schema, $legacy_field));
+            WACC()->Log()->info('Migrated legacy profile image MDP slug pair into composite ref.', [
+                'source'      => __CLASS__,
+                'schema_slug' => $legacy_schema,
+                'field_slug'  => $legacy_field,
+            ]);
+        }
+
+        update_option(self::MIGRATION_FLAG, true);
+    }
+
+    /**
+     * Read a legacy option from the HyperFields array, with a standalone
+     * get_option() fallback for pre-HFMigration storage.
+     */
+    private function readLegacyOption(string $key): string
+    {
+        $value = WACC()->getOption($key, '');
+        if (is_string($value) && trim($value) !== '') {
+            return trim($value);
+        }
+
+        $fallback = get_option($key, '');
+
+        return is_string($fallback) ? trim($fallback) : '';
+    }
+
+    /**
+     * Write a single key into the wicket_acc_options array (HyperFields storage).
+     */
+    private function writeMainOption(string $key, string $value): void
+    {
+        $options = get_option(InitOptions::MAIN_OPTION_NAME, []);
+        if (!is_array($options)) {
+            $options = [];
+        }
+
+        $options[$key] = $value;
+        update_option(InitOptions::MAIN_OPTION_NAME, $options);
+    }
+
+    /**
+     * Render the profile-image MDP field picker (HyperFields CustomField).
+     *
+     * Outputs a grouped <select> (No syncing + one optgroup per schema slug)
+     * plus a Refresh button. The Refresh button calls the refresh REST route
+     * via the bundled admin JS, which rebuilds the select from the response.
+     *
+     * @param array  $field_data HyperFields field data (name, name_attr, label, ...).
+     * @param mixed  $value      Currently stored composite ref.
+     */
+    public static function renderField(array $field_data, $value): void
+    {
+        $field_id = isset($field_data['name']) && is_string($field_data['name']) ? $field_data['name'] : self::OPTION_KEY;
+        $name_attr = isset($field_data['name_attr']) && is_string($field_data['name_attr']) ? $field_data['name_attr'] : self::OPTION_KEY;
+        $label = isset($field_data['label']) && is_string($field_data['label']) ? $field_data['label'] : __('Profile image MDP field', 'wicket-acc');
+        $value = is_string($value) ? $value : '';
+
+        $options = WACC()->Mdp()->Schema()->getCachedProfileImageFieldOptions();
+
+        $rest_url = rest_url(self::REST_NAMESPACE . self::REST_ROUTE);
+        $nonce = wp_create_nonce('wp_rest');
+
+        $no_syncing_label = __('No syncing (keep image local)', 'wicket-acc');
+        $refresh_label = __('Refresh fields', 'wicket-acc');
+        $refreshing_label = __('Refreshing...', 'wicket-acc');
+        $error_label = __('Could not refresh the field list. Check the MDP connection and try again.', 'wicket-acc');
+        $help = __('Choose which MDP additional-info field stores the uploaded profile image URL. "No syncing" keeps the image in WordPress only.', 'wicket-acc');
+        ?>
+        <div class="hyperpress-field-wrapper">
+            <div class="hyperpress-field-row">
+                <div class="hyperpress-field-label">
+                    <label for="<?php echo esc_attr($field_id); ?>"><?php echo esc_html($label); ?></label>
+                </div>
+                <div class="hyperpress-field-input-wrapper" data-wicket-acc-mdp-fields>
+                    <select id="<?php echo esc_attr($field_id); ?>"
+                            name="<?php echo esc_attr($name_attr); ?>"
+                            class="regular-text"
+                            data-wicket-acc-mdp-fields-select
+                            data-wicket-no-syncing-label="<?php echo esc_attr($no_syncing_label); ?>">
+                        <option value="" <?php selected($value, ''); ?>><?php echo esc_html($no_syncing_label); ?></option>
+                        <?php foreach ($options as $group) :
+                            $schema_slug = isset($group['schema_slug']) && is_string($group['schema_slug']) ? $group['schema_slug'] : '';
+                            $schema_label = isset($group['schema_label']) && is_string($group['schema_label']) ? $group['schema_label'] : $schema_slug;
+                            $fields = isset($group['fields']) && is_array($group['fields']) ? $group['fields'] : [];
+                            if ($schema_slug === '' || empty($fields)) {
+                                continue;
+                            }
+                            ?>
+                            <optgroup label="<?php echo esc_attr($schema_label); ?>">
+                                <?php foreach ($fields as $field) :
+                                    $field_slug = isset($field['slug']) && is_string($field['slug']) ? $field['slug'] : '';
+                                    $field_label = isset($field['label']) && is_string($field['label']) ? $field['label'] : $field_slug;
+                                    if ($field_slug === '') {
+                                        continue;
+                                    }
+                                    $ref = self::formatFieldRef($schema_slug, $field_slug);
+                                    ?>
+                                    <option value="<?php echo esc_attr($ref); ?>" <?php selected($value, $ref); ?>>
+                                        <?php echo esc_html($field_label); ?>
+                                    </option>
+                                <?php endforeach; ?>
+                            </optgroup>
+                        <?php endforeach; ?>
+                    </select>
+
+                    <button type="button"
+                            class="button"
+                            data-wicket-acc-mdp-fields-refresh-button
+                            data-rest-url="<?php echo esc_url($rest_url); ?>"
+                            data-nonce="<?php echo esc_attr($nonce); ?>"
+                            data-refreshing-label="<?php echo esc_attr($refreshing_label); ?>"
+                            data-error-label="<?php echo esc_attr($error_label); ?>">
+                        <?php echo esc_html($refresh_label); ?>
+                    </button>
+
+                    <p class="description"><?php echo esc_html($help); ?></p>
+                </div>
+            </div>
+        </div>
+        <?php
+    }
+
+    /**
+     * Sanitize/validate the composite ref at settings-save time.
+     *
+     * Empty is valid (No syncing). A non-empty ref must parse and must exist in
+     * the live field list. On drift (field removed from MDP), keep the
+     * previously stored value rather than wipe it. This runs only on save, never
+     * on the upload path.
+     *
+     * @param mixed $value Submitted value.
+     *
+     * @return string Cleaned composite ref, or empty for No syncing.
+     */
+    public static function sanitizeField($value): string
+    {
+        $value = is_string($value) ? trim($value) : '';
+        if ($value === '') {
+            return self::NO_SYNCING;
+        }
+
+        $parsed = self::parseFieldRef($value);
+        if ($parsed === null) {
+            return self::currentStoredRef();
+        }
+
+        [$schema_slug, $field_slug] = $parsed;
+        if (self::refExistsInLiveList($schema_slug, $field_slug)) {
+            return self::formatFieldRef($schema_slug, $field_slug);
+        }
+
+        WACC()->Log()->warning('Profile image MDP field ref not found in live list; keeping previous value.', [
+            'source'   => __CLASS__,
+            'submitted' => $value,
+        ]);
+
+        return self::currentStoredRef();
+    }
+
+    /**
+     * Whether a composite ref exists in the current (cached) field list.
+     */
+    private static function refExistsInLiveList(string $schema_slug, string $field_slug): bool
+    {
+        foreach (WACC()->Mdp()->Schema()->getCachedProfileImageFieldOptions() as $group) {
+            if (($group['schema_slug'] ?? '') !== $schema_slug) {
+                continue;
+            }
+            foreach ($group['fields'] ?? [] as $field) {
+                if (($field['slug'] ?? '') === $field_slug) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Read the currently stored composite ref from the options array.
+     */
+    private static function currentStoredRef(): string
+    {
+        $stored = WACC()->getOption(self::OPTION_KEY, self::NO_SYNCING);
+
+        return is_string($stored) ? $stored : self::NO_SYNCING;
+    }
+}


### PR DESCRIPTION
## What

The Account Centre profile picture block can now write its uploaded image URL to a configurable MDP additional_info field, so downstream systems (Higher Logic on OBA) can read it. The target field is picked dynamically from the tenant's own schemas, so it works for every customer without hardcoding slugs.

## Why

WWID-1911 (OBA AC3). The target slug is not the same across tenants: OBA uses `profprofile.memberphotourl`, others use `personal_info.photo_link`. The old integration used two free-text options that required knowing the exact slugs in advance and silently fell back to defaults that may not exist on the tenant. This makes the target a first-class, discoverable setting with a safe default.

## How

- One ACC Option, `acc_profile_picture_mdp_field_ref`, stores a composite ref `{schema_slug}|{field_slug}`. The default is empty, which means **No syncing**: the upload stays local and the MDP call is skipped.
- The picker is a grouped select sourced live from the tenant `json_schemas` endpoint (`Schema::getProfileImageFieldOptions()`), cached in a transient. A Refresh button clears the cache through `POST /wicket-acc/v1/profile-image-mdp-fields/refresh`.
- Only URL-capable fields appear: free-text strings and `format:uri` fields. Enum, boolean, number, and composite (repeater, object) fields are excluded.
- `Profile::syncProfileImageToMdp()` short-circuits on No syncing. When configured, it preserves sibling fields in the schema (only the chosen field is touched) and retries once on a 409 record conflict.
- A one-time migration reads the legacy free-text pair and writes the composite ref, so tenants already configured keep syncing with no action from the Implementation Specialist.
- Rendered through a HyperFields `CustomField` (the stock select is flat-only and cannot do optgroups), with a small admin JS asset enqueued only on the ACC Options page.

## Testing

- 18 unit tests in `wicket-warden` cover the enumerator (grouping, JSON:API wrapper, composite and enum exclusion, label resolution), the ref parse/format round-trip, and sanitize (empty, valid, drift keeps previous, malformed). Full AccountCentre unit suite is green; the one unrelated failure is `AdditionalSeatsServiceTest` (WWID-2115, membership path).
- End to end on local OBA staging (MDP synced to `oba-api.staging`): the enumerator returns `profprofile.memberphotourl`; a real URL was written to a person's `memberphotourl` with a sibling `biography` preserved; No-syncing short-circuit verified (no write); migration verified; the REST refresh returns 200 with the grouped list; the picker renders and the Refresh button works in the browser.

<img width="1049" height="122" alt="image" src="https://github.com/user-attachments/assets/7708e9e4-f326-44a5-9672-8a3deaf98dec" />

<img width="633" height="312" alt="image" src="https://github.com/user-attachments/assets/7467905b-35eb-4943-8eec-960dbf986bb1" />

## Notes

- The two legacy free-text options are removed. Configured values migrate automatically. The default changes from the old hardcoded `personal_info` / `photo_link` fallback to No syncing (local only), which is the safer default.
- Release marker set to `#minor` (new setting, REST route, and behavior change). Atlas plan: `wicket-wp-stack/atlas/plans/feature-acc-profile-image-mdp-field-picker.md`.