### PR TITLE
fix(mdp): access WACC MDP service via method call, not property

### DIFF
--- a/includes/legacy.php
+++ b/includes/legacy.php
@@ -20,7 +20,7 @@ defined('ABSPATH') || exit;
 /**
  * Returns active memberships from wicket API.
  *
- * @deprecated 1.6.0 Available as method WACC()->Mdp->Membership->getCurrentPersonActiveMemberships()
+ * @deprecated 1.6.0 Available as method WACC()->Mdp()->Membership()->getCurrentPersonActiveMemberships()
  */
 function wicket_get_active_memberships($iso_code = 'en')
 {
@@ -32,7 +32,7 @@ function wicket_get_active_memberships($iso_code = 'en')
 /**
  * Returns active memberships from WooCommerce.
  *
- * @deprecated 1.6.0 Available as method WACC()->Mdp->Membership->getCurrentUserWooActiveMemberships()
+ * @deprecated 1.6.0 Available as method WACC()->Mdp()->Membership()->getCurrentUserWooActiveMemberships()
  */
 function woo_get_active_memberships()
 {
@@ -44,7 +44,7 @@ function woo_get_active_memberships()
 /**
  * Returns active memberships relationship from wicket API.
  *
- * @deprecated 1.6.0 Available as method WACC()->Mdp->Membership->getActiveMembershipRelationship()
+ * @deprecated 1.6.0 Available as method WACC()->Mdp()->Membership()->getActiveMembershipRelationship()
  */
 function wicket_get_active_memberships_relationship($org_uuid)
 {

--- a/src/Mdp/Init.php
+++ b/src/Mdp/Init.php
@@ -302,7 +302,7 @@ class Init
      */
     public function __call(string $name, array $arguments)
     {
-        // Support method-based access like WACC()->Mdp()->Person() instead of WACC()->Mdp->Person
+        // Support method-based access like WACC()->Mdp()->Person()
         return $this->__get($name);
     }
 }

--- a/src/WicketORM/Services/BusinessInfoService.php
+++ b/src/WicketORM/Services/BusinessInfoService.php
@@ -238,7 +238,7 @@ class BusinessInfoService
             return new WP_Error('missing_client', __('MDP client is not available.', 'wicket-acc'));
         }
 
-        $client = WACC()->MdpApi->init_client();
+        $client = WACC()->Mdp()->init_client();
 
         $results = [];
 


### PR DESCRIPTION
## Context

Ref: https://app.asana.com/1/1138832104141584/task/1217100047432521?focus=true

## Problem

`/my-account/organization-management/` fatals on staging (PHCA):

    PHP Fatal: Call to a member function init_client() on null
      at wicket-child .../acc-orgman-index.php:28

`WicketAcc` exposes services only through `__call` since 1.5.264
(commit 11366bda, "better Method-Based calls"), which removed `__get`.
Property access like `WACC()->MdpApi` is no longer intercepted and
returns null, so `->init_client()` fatals.

## Changes

- `src/WicketORM/Services/BusinessInfoService.php`: the one broken caller inside the plugin, `WACC()->MdpApi->init_client()`, switched to the canonical `WACC()->Mdp()->init_client()`.
- `includes/legacy.php`: three `@deprecated` docblocks documented the broken property form; now show `WACC()->Mdp()->Membership()->...` to match the actual function bodies.
- `src/Mdp/Init.php`: comment no longer mentions the property form.

## Verification

- `php -l` clean on all three files.
- Repo-wide audit (excl `vendor/`): zero remaining `WACC()->Mdp->` / `WACC()->MdpApi->` property forms; `atlas/` docs already use canonical `WACC()->Mdp()`.
- php-cs-fixer is not installed locally; CI runs it.