### PR TITLE
fix(roster): stop createConnection masking payload-build errors (WWID-1884)

### DIFF
--- a/src/WicketORM/Services/ConnectionService.php
+++ b/src/WicketORM/Services/ConnectionService.php
@@ -451,7 +451,20 @@ class ConnectionService
      */
     public function createConnection($payload)
     {
+        // Propagate a caller-supplied WP_Error verbatim. buildConnectionPayload()
+        // can return a WP_Error (e.g. a missing required relationship type), and
+        // wrapping it here would mask the real cause behind "Valid payload array
+        // is required.", hiding the actual failure from operators and logs.
+        if (is_wp_error($payload)) {
+            return $payload;
+        }
+
         if (empty($payload) || !is_array($payload)) {
+            \Wicket()->log()->error('ConnectionService::createConnection() aborted: payload is not a valid connection array.', [
+                'source' => 'wicket-orgman',
+                'payload_type' => is_object($payload) ? get_class($payload) : gettype($payload),
+            ]);
+
             return new WP_Error('invalid_params', 'Valid payload array is required.');
         }
 

--- a/src/WicketORM/Services/Strategies/CascadeStrategy.php
+++ b/src/WicketORM/Services/Strategies/CascadeStrategy.php
@@ -329,6 +329,17 @@ class CascadeStrategy implements RosterManagementStrategy
                         $relationship_type,
                         $relationship_description
                     );
+
+                    // Surface a payload-build failure directly instead of letting
+                    // createConnection() mask it as "Valid payload array is required."
+                    if (is_wp_error($connection_payload)) {
+                        $logger->error('[OrgMan] Cascade strategy failed to build connection payload', array_merge($log_context, [
+                            'error' => $connection_payload->get_error_message(),
+                        ]));
+
+                        return $connection_payload;
+                    }
+
                     $connection_response = $this->connectionService()->createConnection($connection_payload);
 
                     if (is_wp_error($connection_response)) {

--- a/src/WicketORM/Services/Strategies/DirectAssignmentStrategy.php
+++ b/src/WicketORM/Services/Strategies/DirectAssignmentStrategy.php
@@ -152,6 +152,17 @@ class DirectAssignmentStrategy implements RosterManagementStrategy
                         $relationship_description
                     );
 
+                    // A WP_Error here means the payload could not be built (missing
+                    // person/org/type). Surface the real cause instead of letting
+                    // createConnection() mask it as "Valid payload array is required."
+                    if (is_wp_error($connection_payload)) {
+                        $logger->error('Failed to build connection payload', array_merge($log_context, [
+                            'error' => $connection_payload->get_error_message(),
+                        ]));
+
+                        return $connection_payload;
+                    }
+
                     $response_connection = $this->connectionService()->createConnection($connection_payload);
 
                     if (is_wp_error($response_connection)) {

--- a/src/WicketORM/Services/Strategies/GroupsStrategy.php
+++ b/src/WicketORM/Services/Strategies/GroupsStrategy.php
@@ -194,6 +194,17 @@ class GroupsStrategy implements RosterManagementStrategy
                         $relationship_type,
                         $relationship_description
                     );
+
+                    // Surface a payload-build failure directly instead of letting
+                    // createConnection() mask it as "Valid payload array is required."
+                    if (is_wp_error($connection_payload)) {
+                        $logger->error('Groups strategy failed to build connection payload', array_merge($log_context, [
+                            'error' => $connection_payload->get_error_message(),
+                        ]));
+
+                        return $connection_payload;
+                    }
+
                     $connection_result = $this->connectionService()->createConnection($connection_payload);
 
                     if (is_wp_error($connection_result)) {


### PR DESCRIPTION
Ref: WWID-1884 — https://app.asana.com/1/1138832104141584/task/1215843197920883?focus=true

Stops the roster connection-creation path from masking the real error when a strategy hands `createConnection()` a `WP_Error` from `buildConnectionPayload()`.

## Why
On CCHL, add-member surfaced `Valid payload array is required.` even though the underlying cause was a rejected payload build (empty relationship type on a config that disables the field). The opaque message hid the real failure and wrote nothing to the logs, which turned a config issue into a long debug.

## Changes
- `ConnectionService::createConnection` propagates a passed-in `WP_Error` as-is, and logs the genuinely-invalid-payload branch.
- `CascadeStrategy`, `DirectAssignmentStrategy`, and `GroupsStrategy` guard `is_wp_error()` on the built payload before calling `createConnection`, and return the real error with a log line.
- No behaviour change on the happy path.

## Tests
Roster suite passes (45/45), including new regression coverage in the wicket-warden repo on a matching branch (`fix/WWID-1884-connection-payload-masking`).

Companion PRs: base-plugin helper fix (separate) and the matching qa branch.