### PR TITLE
fix(security): close object injection and output XSS in touchpoint blocks

### DIFF
--- a/includes/blocks/ac-touchpoint-event-calendar/ajax.php
+++ b/includes/blocks/ac-touchpoint-event-calendar/ajax.php
@@ -12,9 +12,9 @@ class ajax extends init
      */
     public function __construct()
     {
-        // Register Ajax actions
+        // Register Ajax actions. Logged-in users only: this endpoint serves the
+        // current member's personal touchpoint data, which a guest never has.
         add_action('wp_ajax_wicket_ac_touchpoint_tec_results', [$this, 'ajax_load_more_results']);
-        add_action('wp_ajax_nopriv_wicket_ac_touchpoint_tec_results', [$this, 'ajax_load_more_results']);
     }
 
     /**
@@ -46,10 +46,15 @@ class ajax extends init
         $total_results = isset($_POST['total_results']) ? absint($_POST['total_results']) : 0;
         $counter = isset($_POST['counter']) ? absint($_POST['counter']) : 0;
         $display_type = isset($_POST['type']) ? sanitize_text_field($_POST['type']) : 'upcoming';
-        $touchpoint_data_input = $_POST['touchpoint_data'] ?? '';
+        $touchpoint_data_input = isset($_POST['touchpoint_data']) ? wp_unslash($_POST['touchpoint_data']) : '';
 
-        // Get touchpoints data
-        $touchpoint_data = maybe_unserialize(base64_decode($touchpoint_data_input));
+        // Decode the touchpoint data. The producer (init.php) base64-encodes a
+        // JSON string, so we JSON-decode it here. Never unserialize request input.
+        $decoded = base64_decode($touchpoint_data_input, true);
+        $touchpoint_data = $decoded === false ? [] : json_decode($decoded, true);
+        if (!is_array($touchpoint_data)) {
+            $touchpoint_data = [];
+        }
 
         // Note: The Event Calendar block pre-filters data using the new Touchpoint filtering system
         // with start_date and end_date field keys, so this AJAX handler works with already-filtered data

--- a/includes/blocks/ac-touchpoint-event-calendar/init.php
+++ b/includes/blocks/ac-touchpoint-event-calendar/init.php
@@ -267,7 +267,7 @@ class init extends Blocks
         $num_results = absint($num_results);
         $total_results = absint($total_results);
         $counter = absint($counter);
-        $touchpoint_data_input = base64_encode(maybe_serialize($touchpoint_data));
+        $touchpoint_data_input = base64_encode(wp_json_encode($touchpoint_data) ?: '[]');
         $received_results_count = count($touchpoint_data);
         ?>
 

--- a/includes/blocks/ac-touchpoint-moodle/ajax.php
+++ b/includes/blocks/ac-touchpoint-moodle/ajax.php
@@ -12,9 +12,9 @@ class ajax extends init
      */
     public function __construct()
     {
-        // Register Ajax actions
+        // Register Ajax actions. Logged-in users only: this endpoint serves the
+        // current member's personal touchpoint data, which a guest never has.
         add_action('wp_ajax_wicket_ac_touchpoint_moodle_results', [$this, 'ajax_load_more_results']);
-        add_action('wp_ajax_nopriv_wicket_ac_touchpoint_moodle_results', [$this, 'ajax_load_more_results']);
     }
 
     /**
@@ -46,10 +46,15 @@ class ajax extends init
         $total_results = isset($_POST['total_results']) ? absint($_POST['total_results']) : 0;
         $counter = isset($_POST['counter']) ? absint($_POST['counter']) : 0;
         $display_type = isset($_POST['type']) ? sanitize_text_field($_POST['type']) : 'upcoming';
-        $touchpoint_data_input = $_POST['touchpoint_data'] ?? '';
+        $touchpoint_data_input = isset($_POST['touchpoint_data']) ? wp_unslash($_POST['touchpoint_data']) : '';
 
-        // Get touchpoints data
-        $touchpoint_data = maybe_unserialize(base64_decode($touchpoint_data_input));
+        // Decode the touchpoint data. The producer (init.php) base64-encodes a
+        // JSON string, so we JSON-decode it here. Never unserialize request input.
+        $decoded = base64_decode($touchpoint_data_input, true);
+        $touchpoint_data = $decoded === false ? [] : json_decode($decoded, true);
+        if (!is_array($touchpoint_data)) {
+            $touchpoint_data = [];
+        }
 
         // We will get $this->display_touchpoints results and return it as html
         // Ideally, we should return the results as json, but... i don't know if Wicket has any standard way to render json results on the front-end

--- a/includes/blocks/ac-touchpoint-moodle/init.php
+++ b/includes/blocks/ac-touchpoint-moodle/init.php
@@ -291,7 +291,7 @@ class init extends Blocks
         $num_results = absint($num_results);
         $total_results = absint($total_results);
         $counter = absint($counter);
-        $touchpoint_data_input = base64_encode(maybe_serialize($touchpoint_data));
+        $touchpoint_data_input = base64_encode(wp_json_encode($touchpoint_data) ?: '[]');
         $received_results_count = count($touchpoint_data);
         ?>
 

--- a/includes/blocks/ac-touchpoint-zoom/ajax.php
+++ b/includes/blocks/ac-touchpoint-zoom/ajax.php
@@ -45,10 +45,15 @@ class ajax extends init
         $total_results = isset($_POST['total_results']) ? absint($_POST['total_results']) : 0;
         $counter = isset($_POST['counter']) ? absint($_POST['counter']) : 0;
         $display_type = isset($_POST['type']) ? sanitize_text_field($_POST['type']) : 'upcoming';
-        $touchpoint_data_input = $_POST['touchpoint_data'] ?? '';
+        $touchpoint_data_input = isset($_POST['touchpoint_data']) ? wp_unslash($_POST['touchpoint_data']) : '';
 
-        // Get touchpoints data
-        $touchpoint_data = maybe_unserialize(base64_decode($touchpoint_data_input));
+        // Decode the touchpoint data. The producer (init.php) base64-encodes a
+        // JSON string, so we JSON-decode it here. Never unserialize request input.
+        $decoded = base64_decode($touchpoint_data_input, true);
+        $touchpoint_data = $decoded === false ? [] : json_decode($decoded, true);
+        if (!is_array($touchpoint_data)) {
+            $touchpoint_data = [];
+        }
 
         // We will get $this->display_touchpoints results and return it as html
         // Ideally, we should return the results as json, but... i don't know if Wicket has any standar way to render json results on the front-end

--- a/includes/blocks/ac-touchpoint-zoom/init.php
+++ b/includes/blocks/ac-touchpoint-zoom/init.php
@@ -310,7 +310,7 @@ class init extends Blocks
     public static function load_more_results($touchpoint_data = [], $num_results = 5, $total_results = 0, $counter = 0, $display_type = 'upcoming', $ajax = false, $block_id = 0)
     {
         // Encode touchpoint data for ajax
-        $touchpoint_data_encoded = base64_encode(serialize($touchpoint_data));
+        $touchpoint_data_encoded = base64_encode(wp_json_encode($touchpoint_data) ?: '[]');
 
         // Calculate remaining results
         $remaining_results = $total_results - $counter;

--- a/templates-wicket/blocks/account-centre/touchpoint-moodle-card.php
+++ b/templates-wicket/blocks/account-centre/touchpoint-moodle-card.php
@@ -28,37 +28,37 @@ $grade_percentage = $tp['attributes']['data']['final_grade']['percentageformatte
 ?>
 
 <div class="event-card <?php echo defined('WICKET_WP_THEME_V2') ? '' : 'my-0 p-6 border border-gray-200 gap-6 rounded-md shadow-md flex-row' ?>"
-    data-uuid="<?php echo $tp['id']; ?>">
+    data-uuid="<?php echo esc_attr($tp['id']); ?>">
 
-    <h2 class='text-lg'><?php echo $action ?></h2>
+    <h2 class='text-lg'><?php echo esc_html($action); ?></h2>
 
     <?php if ($action_code == 'completed_a_course'): ?>
         <div class="flex-auto md:w-auto event-content-wrap space-y-4">
-            <p><?php echo $course_name ?></p>
+            <p><?php echo esc_html($course_name); ?></p>
             
             <p class="event-date <?php echo defined('WICKET_WP_THEME_V2') ? '' : 'text-sm leading-relaxed' ?>">
-                <strong><?php _e('Course ID:', 'wicket-acc'); ?></strong> <?php echo $course_id; ?>
+                <strong><?php _e('Course ID:', 'wicket-acc'); ?></strong> <?php echo esc_html($course_id); ?>
             </p>
             
             <p class="event-date <?php echo defined('WICKET_WP_THEME_V2') ? '' : 'text-sm leading-relaxed' ?>">
-                <strong><?php _e('Start Date:', 'wicket-acc'); ?></strong> <?php echo $course_start_date; ?>
+                <strong><?php _e('Start Date:', 'wicket-acc'); ?></strong> <?php echo esc_html($course_start_date); ?>
             </p>
             
             <?php if ($course_end_date): ?>
             <p class="event-date <?php echo defined('WICKET_WP_THEME_V2') ? '' : 'text-sm leading-relaxed' ?>">
-                <strong><?php _e('End Date:', 'wicket-acc'); ?></strong> <?php echo $course_end_date; ?>
+                <strong><?php _e('End Date:', 'wicket-acc'); ?></strong> <?php echo esc_html($course_end_date); ?>
             </p>
             <?php endif; ?>
             
             <?php if ($grade_achieved): ?>
             <p class="event-date <?php echo defined('WICKET_WP_THEME_V2') ? '' : 'text-sm leading-relaxed' ?>">
-                <strong><?php _e('Grade Achieved:', 'wicket-acc'); ?></strong> <?php echo $grade_achieved; ?>
+                <strong><?php _e('Grade Achieved:', 'wicket-acc'); ?></strong> <?php echo esc_html($grade_achieved); ?>
             </p>
             <?php endif; ?>
             
             <?php if ($grade_percentage): ?>
             <p class="event-date <?php echo defined('WICKET_WP_THEME_V2') ? '' : 'text-sm leading-relaxed' ?>">
-                <strong><?php _e('Grade Percentage:', 'wicket-acc'); ?></strong> <?php echo $grade_percentage; ?>
+                <strong><?php _e('Grade Percentage:', 'wicket-acc'); ?></strong> <?php echo esc_html($grade_percentage); ?>
             </p>
             <?php endif; ?>
         </div>
@@ -66,19 +66,19 @@ $grade_percentage = $tp['attributes']['data']['final_grade']['percentageformatte
 
     <?php if ($action_code == 'enrolled_in_a_course'): ?>
         <div class="flex-auto md:w-auto event-content-wrap space-y-4">
-            <p><?php echo $course_name ?></p>
+            <p><?php echo esc_html($course_name); ?></p>
             
             <p class="event-date <?php echo defined('WICKET_WP_THEME_V2') ? '' : 'text-sm leading-relaxed' ?>">
-                <strong><?php _e('Course ID:', 'wicket-acc'); ?></strong> <?php echo $course_id; ?>
+                <strong><?php _e('Course ID:', 'wicket-acc'); ?></strong> <?php echo esc_html($course_id); ?>
             </p>
             
             <p class="event-date <?php echo defined('WICKET_WP_THEME_V2') ? '' : 'text-sm leading-relaxed' ?>">
-                <strong><?php _e('Start Date:', 'wicket-acc'); ?></strong> <?php echo $enrolled_start_date; ?>
+                <strong><?php _e('Start Date:', 'wicket-acc'); ?></strong> <?php echo esc_html($enrolled_start_date); ?>
             </p>
             
             <?php if ($enrolled_end_date): ?>
             <p class="event-date <?php echo defined('WICKET_WP_THEME_V2') ? '' : 'text-sm leading-relaxed' ?>">
-                <strong><?php _e('End Date:', 'wicket-acc'); ?></strong> <?php echo $enrolled_end_date; ?>
+                <strong><?php _e('End Date:', 'wicket-acc'); ?></strong> <?php echo esc_html($enrolled_end_date); ?>
             </p>
             <?php endif; ?>
         </div>
@@ -86,10 +86,10 @@ $grade_percentage = $tp['attributes']['data']['final_grade']['percentageformatte
 
     <?php if ($action_code == 'created_account'): ?>
         <div class="flex-auto md:w-auto event-content-wrap space-y-4">
-            <p><?php echo $course_name ?></p>
+            <p><?php echo esc_html($course_name); ?></p>
             
             <p class="event-date <?php echo defined('WICKET_WP_THEME_V2') ? '' : 'text-sm leading-relaxed' ?>">
-                <?php _e($details, 'wicket-acc'); ?>
+                <?php echo esc_html($details); ?>
             </p>
         </div>
     <?php endif; ?>


### PR DESCRIPTION
## What
Closes a PHP object injection sink (F-05) in the Moodle, Zoom, and Event Calendar touchpoint blocks, plus an unescaped-output XSS in the Moodle touchpoint card that rides the same "Load More" path.

## Why
The three blocks round-tripped their result set through the browser as a base64'd PHP-serialized blob and fed the POSTed bytes back to `maybe_unserialize()`. Because the endpoints were also registered on `wp_ajax_nopriv_`, the sink was reachable unauthenticated. The data is the current member's personal touchpoint history (`getCurrentUserTouchpoints` returns false when there is no current person), so a guest never has data here and the unauthenticated registration carried only attack surface.

## How
- Replaced `maybe_unserialize(base64_decode(...))` with `json_decode` in all three ajax handlers; the producers now base64-encode JSON via `wp_json_encode`. Decode always normalizes to an array.
- Dropped the `wp_ajax_nopriv_` registration in moodle and event-calendar (zoom was already auth-only).
- Escaped output in `touchpoint-moodle-card.php` with `esc_html` / `esc_attr` to match the existing zoom card, which was already correct.
- No JavaScript changes; the blob stays opaque to the client.

## Testing
- [x] `php -l` on all seven changed files
