### PR TITLE
docs: add PR description template #norelease

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+Wicket PR template. Full spec: atlas/conventions/pr-template.md
+-->
+
+## Context
+Task ID: <WWID-####>
+Task Link: <task link>
+Related PRs: <links, or "none">
+
+## What
+<!-- State the current issue in 1-2 sentences. What happens today? Keep it brief, this is the intro. -->
+
+## Why
+<!-- Explain in more detail why this issue matters and why it needs a fix. Add context. Keep it brief. -->
+
+## How
+<!--
+Give a detailed technical explanation: what you changed and why you chose that approach.
+Use ### subheadings under What/Why/How when a change spans multiple areas (e.g. ### API, ### Data, ### Frontend).
+Subheadings are optional — only add them when one section covers more than one distinct area of change.
+-->
+
+<!-- No sensitive info: no real names, API keys/secrets, or client-specific identifiers. This PR may be public. -->


### PR DESCRIPTION
## Context
Task ID: none
Task Link: none
Related PRs: none

## What
No standard PR description structure exists for wicket stack repos. PR bodies vary freely between one-liners and full write-ups.

## Why
Reviewers need consistent structure to scan intent, rationale, and implementation without hunting through prose. A fixed shape also keeps the auto-generated changelog legible once branches are deleted.

## How
Adds `.github/PULL_REQUEST_TEMPLATE.md` matching the Context/What/Why/How convention defined in `wicket-atlas/conventions/pr-template.md`. `gh pr create` and the GitHub UI now default to this structure for this repo.