### PR TITLE
fix(org-management): stop org_id/org_uuid redirect loop on legacy rosters

### DIFF
--- a/src/Shortcodes.php
+++ b/src/Shortcodes.php
@@ -40,6 +40,9 @@ class Shortcodes extends WicketAcc
             return '';
         }
 
+        // Legacy URLs may still carry org_id; TemplateHelper::normalize_org_uuid_param()
+        // (template_redirect, priority 0) redirects them to org_uuid before this runs.
+        // Kept as a fallback guard in case that hook does not fire.
         $org_uuid = isset($_GET['org_uuid']) ? sanitize_text_field($_GET['org_uuid']) : '';
         if (empty($org_uuid) && isset($_GET['org_id'])) {
             $org_uuid = sanitize_text_field($_GET['org_id']);
@@ -64,7 +67,7 @@ class Shortcodes extends WicketAcc
         // If user only has one organization, redirect to that organization with url parameters
         if (!empty($org_uuids_list) && count($org_uuids_list) === 1 && empty($org_uuid)) {
             $url = strtok($_SERVER['REQUEST_URI'], '?');
-            $redirect_url = add_query_arg('org_id', $org_uuids_list[0], $url);
+            $redirect_url = add_query_arg('org_uuid', $org_uuids_list[0], $url);
 
             // Use wp_safe_redirect if possible (check headers_sent)
             if (!headers_sent()) {
@@ -119,7 +122,7 @@ class Shortcodes extends WicketAcc
                             <?php if ($linked) { ?>
                                 <i class="fa-solid fa-building w-[20px] h-[20px] text-[var(--color-primary)] shrink-0"></i><a
                                     class='primary_link_color'
-                                    href='<?php echo esc_url(add_query_arg('org_id', $i_org_id, home_url(add_query_arg([], $wp->request)))); ?>'>
+                                    href='<?php echo esc_url(add_query_arg('org_uuid', $i_org_id, home_url(add_query_arg([], $wp->request)))); ?>'>
                                 <?php } else { ?>
                                     <i class="fa-solid fa-ban w-[20px] h-[20px] text-[var(--color-primary)] shrink-0"></i>
                                 <?php } ?>

--- a/src/WicketORM/OrgMan.php
+++ b/src/WicketORM/OrgMan.php
@@ -168,6 +168,10 @@ final class OrgMan
             add_filter('the_content', [$this, 'cleanupOrgmanAutopArtifacts'], 9999);
             add_filter('body_class', [$this, 'addOrgmanBodyClass']);
             add_action('wp_enqueue_scripts', [$this, 'enqueueAssets']);
+
+            // org_id => org_uuid normalization only helps ORM-rendered routes.
+            // Legacy theme rosters read org_id and redirect back to it forever.
+            add_action('init', [Helpers\TemplateHelper::class, 'init']);
         }
 
         add_filter('query_vars', [Helpers\TemplateHelper::class, 'add_hypermedia_query_vars']);
@@ -175,7 +179,6 @@ final class OrgMan
 
         // Initialize helpers
         add_action('init', [Helpers\GravityFormsHelper::class, 'init']);
-        add_action('init', [Helpers\TemplateHelper::class, 'init']);
 
         // Initialize configuration controller
         add_action('init', [$this->controllers['configuration'], 'init']);


### PR DESCRIPTION
## What

- The `[org-selector]` shortcode now emits `org_uuid` in its single-org auto-redirect and its organization list links. A legacy `org_id` fallback read is kept for old URLs.
- `normalize_org_uuid_param()` (org_id → org_uuid redirect) is now registered only when the modern ORM roster is active, inside the existing `!isLegacyRosterActive()` gate in `OrgMan::addHooks()`.

## Why

On sites running the legacy theme roster (theme defines `wicket_orgman_page_role_check`, e.g. PHCA), the normalizer had no consumer. It redirected `?org_id=` URLs to `?org_uuid=`, while the legacy theme templates only read and emit `?org_id=`, producing an infinite 302 ping-pong (`ERR_TOO_MANY_REDIRECTS`) on `/my-account/organization-management/`. Verified via server access logs on PHCA staging: alternating 302s between both params.

## How

- Hypermedia endpoints keep their own scoped `org_id` → `org_uuid` normalization (`TemplateHelper::maybe_handle_hypermedia_request`), so routing is unaffected.
- OrgMan boots at `after_setup_theme` priority 20, so the legacy check sees theme functions in time.

## Testing

- [x] PHCA staging (legacy roster): redirect loop gone, page renders with `?org_id=` legacy link and with `org_uuid` links
- [x] ORM-mode site unaffected (normalizer still active)

Refs WWID-2165