### PR TITLE
fix(seats): remove checkout return URL override, purge roster cache

### DIFF
--- a/src/WicketORM/OrgMan.php
+++ b/src/WicketORM/OrgMan.php
@@ -189,7 +189,6 @@ final class OrgMan
         $this->registerAdditionalSeatsHook('woocommerce_order_status_on-hold');
         $this->registerAdditionalSeatsHook('woocommerce_payment_complete');
 
-        add_filter('woocommerce_get_return_url', [$this, 'filterWoocommerceReturnUrl'], 10, 2);
         add_action(Services\BulkMemberUploadService::CRON_HOOK, [$this, 'processBulkUploadJob'], 10, 1);
 
         if (isset($this->services['member_export'])) {
@@ -742,6 +741,11 @@ final class OrgMan
                 'mdp_membership_id' => $mdp_membership_id,
                 'success' => (bool) $mdp_updated,
             ]));
+
+            if ($mdp_updated) {
+                // Same stale-transient concern as the tier path (WWID-2257): refresh the roster cache.
+                (new Services\CacheService())->invalidateMemberCache($mdp_membership_id, $org_uuid !== '' ? $org_uuid : null);
+            }
         } else {
             $logger->warning('Missing membership UUID for MDP update', array_merge($context, [
                 'order_id' => $order_id,
@@ -786,144 +790,6 @@ final class OrgMan
             'previous_seats' => $current_seats,
             'new_seats' => $new_seats,
         ]);
-    }
-
-    public function filterWoocommerceReturnUrl($return_url, $order)
-    {
-        $logger = \Wicket()->log();
-        $context = ['source' => 'wicket-orgman'];
-
-        if (!$order || !is_object($order)) {
-            return $return_url;
-        }
-
-        $logger->debug('woocommerce_get_return_url invoked', array_merge($context, [
-            'order_id' => is_callable([$order, 'get_id']) ? (int) $order->get_id() : null,
-            'order_status' => is_callable([$order, 'get_status']) ? (string) $order->get_status() : null,
-            'return_url' => (string) $return_url,
-        ]));
-
-        if ($order->get_meta('additional_seats_processed', true)) {
-            $target_url = $this->getOrganizationMembersUrlFromOrder($order) ?: $return_url;
-            $logger->info('Return URL overridden (already processed additional seats)', array_merge($context, [
-                'order_id' => (int) $order->get_id(),
-                'target_url' => (string) $target_url,
-            ]));
-
-            return $target_url;
-        }
-
-        if (!$this->orderHasAdditionalSeats($order)) {
-            return $return_url;
-        }
-
-        $target_url = $this->getOrganizationMembersUrlFromOrder($order) ?: $return_url;
-        $logger->info('Return URL overridden (additional seats order)', array_merge($context, [
-            'order_id' => (int) $order->get_id(),
-            'target_url' => (string) $target_url,
-        ]));
-
-        return $target_url;
-    }
-
-    private function orderHasAdditionalSeats($order)
-    {
-        $logger = \Wicket()->log();
-        $context = ['source' => 'wicket-orgman'];
-
-        $additional_seats_service = $this->services['additional_seats'] ?? null;
-        if (!$additional_seats_service) {
-            $logger->error('Additional seats service missing; cannot detect product', array_merge($context, [
-                'order_id' => is_callable([$order, 'get_id']) ? (int) $order->get_id() : null,
-            ]));
-
-            return false;
-        }
-
-        // Multi-tier: any tier-specific seat product qualifies the order.
-        if ($additional_seats_service->isTierMode()) {
-            foreach ($order->get_items() as $item) {
-                $product = $item->get_product();
-                if (!$product) {
-                    continue;
-                }
-                $tier_slug = $additional_seats_service->classifySeatProduct((int) $product->get_id());
-                if ($tier_slug !== null) {
-                    $logger->debug('Tier seat product detected on order', array_merge($context, [
-                        'order_id' => (int) $order->get_id(),
-                        'order_item_id' => $item->get_id(),
-                        'tier_slug' => $tier_slug,
-                    ]));
-
-                    return true;
-                }
-            }
-        }
-
-        $product_id = $additional_seats_service->getAdditionalSeatsProduct();
-        if (!$product_id) {
-            $logger->error('Additional seats product not found; cannot detect additional seats order', array_merge($context, [
-                'order_id' => is_callable([$order, 'get_id']) ? (int) $order->get_id() : null,
-            ]));
-
-            return false;
-        }
-
-        foreach ($order->get_items() as $item) {
-            $product = $item->get_product();
-            if ($product && (int) $product->get_id() === (int) $product_id) {
-                $logger->debug('Additional seats product detected on order', array_merge($context, [
-                    'order_id' => (int) $order->get_id(),
-                    'order_item_id' => $item->get_id(),
-                    'product_id' => (int) $product_id,
-                ]));
-
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function getOrganizationMembersUrlFromOrder($order)
-    {
-        $logger = \Wicket()->log();
-        $context = ['source' => 'wicket-orgman'];
-
-        $org_uuid = (string) $order->get_meta('org_uuid', true);
-        if ($org_uuid === '') {
-            foreach ($order->get_items() as $item) {
-                $org_uuid = (string) $item->get_meta('org_uuid', true);
-                if ($org_uuid !== '') {
-                    break;
-                }
-            }
-        }
-
-        $logger->debug('Resolved org_uuid for return URL', array_merge($context, [
-            'order_id' => is_callable([$order, 'get_id']) ? (int) $order->get_id() : null,
-            'org_uuid_present' => $org_uuid !== '',
-        ]));
-
-        // Get WPML-aware URL for organization-members page
-        $base_url = Helpers\Helper::getMyAccountPageUrl('organization-members', '/my-account/organization-members/');
-
-        $logger->debug('Resolved base organization-members URL', array_merge($context, [
-            'order_id' => is_callable([$order, 'get_id']) ? (int) $order->get_id() : null,
-            'base_url' => (string) $base_url,
-        ]));
-
-        if ($org_uuid !== '') {
-            $url = add_query_arg('org_uuid', $org_uuid, $base_url);
-            $logger->debug('Built organization-members return URL', array_merge($context, [
-                'order_id' => is_callable([$order, 'get_id']) ? (int) $order->get_id() : null,
-                'url' => (string) $url,
-            ]));
-
-            return $url;
-        }
-
-        return $base_url;
     }
 
     /**
@@ -1095,6 +961,10 @@ final class OrgMan
         $logger->info('Tier seat increase applied', array_merge($context, [
             'new_max_assignments' => $new_max,
         ]));
+
+        // Drop cached org-membership data so the Account Centre roster picks up the new seat
+        // limit immediately instead of serving the stale max_assignments transient (WWID-2257).
+        (new Services\CacheService())->invalidateMemberCache($membership_id, $org_uuid !== '' ? $org_uuid : null);
 
         return true;
     }


### PR DESCRIPTION
## Context
Task ID: WWID-2257
Task Link: https://app.asana.com/1/1138832104141584/task/1217326985802219
Related PRs: none

## What
I found two bugs in the "Need more seats" checkout. After paying, the customer landed on an org roster (often the wrong membership's roster) instead of the order confirmation page, and the paid order stayed in pending payment until an admin moved it to processing by hand. And once the order did process, the portal roster kept the old seat count until the membership cache expired on its own.

## Why
Our OrgMan `woocommerce_get_return_url` filter was rewriting the gateway return URL for every seats order. Stripe only finalizes a Checkout Session on the order-received page: `maybe_process_checkout_session_redirect()` returns early unless `is_order_received_page()` and the order key are present. The browser came back to the roster URL carrying `wc_stripe_cs=1`, the finalizer bailed, and the order sat in pending even though the card was charged. I confirmed this on staging with order 2747: the access log shows the return hitting `organization-members` with `wc_stripe_cs=1`, and the order notes show an admin moving it to processing 100 seconds later. The roster URL also carried no membership context, so multi-membership orgs fell back to the default membership view.

The stale seat count is a separate miss. The MDP `max_assignments` PATCH after fulfilment never cleared the orgman membership transients, so the seat meter kept serving the cached value until the TTL ran out.

## How
I removed the `woocommerce_get_return_url` override and the three methods only it used (`filterWoocommerceReturnUrl`, `orderHasAdditionalSeats`, `getOrganizationMembersUrlFromOrder`). Paid customers now land on the standard order-received page, the gateway completes the payment there, and the existing status hooks (processing, completed, on-hold, payment complete) already fulfil the seats. Nothing else in the plugin referenced the old redirect.

I also added `CacheService::invalidateMemberCache()` after every successful MDP seat update, in both the tier path and the legacy subscription path, so the roster picks up the new limit right away.

### Cross-client impact
Other clients run the seats flow on this plugin. The override carried the same payment-finalization bug on their seats purchases, so this fixes a latent issue for them too. One behavior change applies everywhere: seats purchases now end on the standard WooCommerce thank-you page instead of the roster. I checked every client org-roster config before making this call.

### Testing
- php -l and php-cs-fixer (repo config) pass on the changed file.
- Staging order 2747 confirms fulfilment once the status reaches processing: tier meta applied, MDP count updated.
- Full checkout pass on staging still pending after deploy: confirmation page, automatic pending-to-processing transition, immediate seat count.