### PR TITLE
feat(org-roster): shared action labels, nav-style details actions, opt-in single-org landing skip #patch

### DIFF
--- a/src/WicketORM/Config/OrgManConfig.php
+++ b/src/WicketORM/Config/OrgManConfig.php
@@ -330,6 +330,13 @@ final class OrgManConfig
             'presentation' => [
                 'organization_details' => [
                     'show_actions' => true,
+                    // Shared labels for the org-profile and manage-members actions.
+                    // Used by the details action nav and the organization list cards
+                    // so both surfaces stay in sync (WWID-2259).
+                    'labels' => [
+                        'org_profile' => __('Org. Profile', 'wicket-acc'),
+                        'manage_members' => __('Manage Members', 'wicket-acc'),
+                    ],
                 ],
                 'organization_list' => [
                     'show_my_role' => true,
@@ -339,6 +346,10 @@ final class OrgManConfig
                     'show_membership_details' => false,
                     'show_organization_name' => true,
                     'show_managed_orgs_summary' => false,
+                    // When true and the user manages exactly one organization with
+                    // an actionable role, the management landing redirects straight
+                    // to that organization instead of showing the one-card list (WWID-2259).
+                    'single_org_skip' => false,
                 ],
                 'relationships' => [
                     'show_type' => false,

--- a/src/WicketORM/Helpers/TemplateHelper.php
+++ b/src/WicketORM/Helpers/TemplateHelper.php
@@ -39,6 +39,30 @@ class TemplateHelper extends Helper
     }
 
     /**
+     * Get a shared organization action label from orgman config.
+     *
+     * Labels for the org-profile and manage-members actions live under
+     * presentation.organization_details.labels so the details action nav and
+     * the organization list cards render identical wording (WWID-2259).
+     *
+     * Supported keys: 'org_profile', 'manage_members'.
+     *
+     * @param string $key Label key.
+     * @return string Label text; stack default when unset or blank.
+     */
+    public static function organization_action_label(string $key): string
+    {
+        $defaults = [
+            'org_profile' => __('Org. Profile', 'wicket-acc'),
+            'manage_members' => __('Manage Members', 'wicket-acc'),
+        ];
+        $labels = \WicketORM\Services\ConfigService::getConfig()['presentation']['organization_details']['labels'] ?? [];
+        $label = is_array($labels) ? trim((string) ($labels[$key] ?? '')) : '';
+
+        return $label !== '' ? $label : (string) ($defaults[$key] ?? $key);
+    }
+
+    /**
      * Detect if it's a template request for our org management system.
      *
      * @return bool

--- a/src/WicketORM/templates-partials/card-organization-direct-cascade.php
+++ b/src/WicketORM/templates-partials/card-organization-direct-cascade.php
@@ -3,6 +3,9 @@
     <?php
     $can_open_org = $can_edit_org || $is_membership_manager;
     $title_url = WicketORM\Helpers\Helper::getMyAccountPageUrl('organization-management', '/my-account/organization-management/') . '?org_uuid=' . urlencode($org_id);
+    // Shared action labels so card links match the details action nav (WWID-2259).
+    $org_profile_label = WicketORM\Helpers\TemplateHelper::organization_action_label('org_profile');
+    $manage_members_label = WicketORM\Helpers\TemplateHelper::organization_action_label('manage_members');
     ?>
     <h2 class="wp-block-heading has-heading-sm-font-size wt_text-2xl wt_mb-3">
         <?php if ($can_open_org): ?>
@@ -160,7 +163,7 @@
                         ?>
                         <a href="<?php echo esc_url(add_query_arg($profile_params, $profile_url_base)); ?>"
                             class="wt_inline-flex wt_items-center wt_text-primary-600 wt_hover_text-primary-700 underline underline-offset-4">
-                            <?php esc_html_e('Edit Organization', 'wicket-acc'); ?>
+                            <?php echo esc_html($org_profile_label); ?>
                         </a>
                     <?php endif; ?>
 
@@ -181,7 +184,7 @@
                         ?>
                         <a href="<?php echo esc_url(add_query_arg($members_params, $members_url_base)); ?>"
                             class="wt_inline-flex wt_items-center wt_text-primary-600 wt_hover_text-primary-700 underline underline-offset-4">
-                            <?php esc_html_e('Manage Members', 'wicket-acc'); ?>
+                            <?php echo esc_html($manage_members_label); ?>
                         </a>
                     <?php endif; ?>
 

--- a/src/WicketORM/templates-partials/card-organization-groups.php
+++ b/src/WicketORM/templates-partials/card-organization-groups.php
@@ -12,6 +12,9 @@
     }
     $title_url = !empty($title_params) ? add_query_arg($title_params, $title_url_base) : $title_url_base;
     $can_open_org = $can_edit_org || $is_membership_manager;
+    // Shared action labels so card links match the details action nav (WWID-2259).
+    $org_profile_label = WicketORM\Helpers\TemplateHelper::organization_action_label('org_profile');
+    $manage_members_label = WicketORM\Helpers\TemplateHelper::organization_action_label('manage_members');
     ?>
     <h2 class="wp-block-heading has-heading-sm-font-size wt_text-2xl wt_mb-3">
         <?php if ($can_open_org): ?>
@@ -128,7 +131,7 @@
                         ?>
                         <a href="<?php echo esc_url(add_query_arg($profile_params, $profile_url_base)); ?>"
                             class="wt_inline-flex wt_items-center wt_text-primary-600 wt_hover_text-primary-700 underline underline-offset-4">
-                            <?php esc_html_e('Edit Organization', 'wicket-acc'); ?>
+                            <?php echo esc_html($org_profile_label); ?>
                         </a>
                     <?php endif; ?>
 
@@ -152,7 +155,7 @@
                         ?>
                         <a href="<?php echo esc_url(add_query_arg($members_params, $members_url_base)); ?>"
                             class="wt_inline-flex wt_items-center wt_text-primary-600 wt_hover_text-primary-700 underline underline-offset-4">
-                            <?php esc_html_e('Manage Members', 'wicket-acc'); ?>
+                            <?php echo esc_html($manage_members_label); ?>
                         </a>
                     <?php endif; ?>
                 </div>

--- a/src/WicketORM/templates-partials/card-organization-membership-cycle.php
+++ b/src/WicketORM/templates-partials/card-organization-membership-cycle.php
@@ -3,6 +3,9 @@
     <?php
     $can_open_org = $can_edit_org || $is_membership_manager;
     $title_url = WicketORM\Helpers\Helper::getMyAccountPageUrl('organization-management', '/my-account/organization-management/') . '?org_uuid=' . urlencode($org_id);
+    // Shared action labels so card links match the details action nav (WWID-2259).
+    $org_profile_label = WicketORM\Helpers\TemplateHelper::organization_action_label('org_profile');
+    $manage_members_label = WicketORM\Helpers\TemplateHelper::organization_action_label('manage_members');
     ?>
     <h2 class="wp-block-heading has-heading-sm-font-size wt_text-2xl wt_mb-3">
         <?php if ($can_open_org): ?>
@@ -143,7 +146,7 @@
                         ?>
                         <a href="<?php echo esc_url(add_query_arg($profile_params, $profile_url_base)); ?>"
                             class="wt_inline-flex wt_items-center wt_text-primary-600 wt_hover_text-primary-700 underline underline-offset-4">
-                            <?php esc_html_e('Edit Organization', 'wicket-acc'); ?>
+                            <?php echo esc_html($org_profile_label); ?>
                         </a>
                     <?php endif; ?>
 
@@ -164,7 +167,7 @@
                         ?>
                         <a href="<?php echo esc_url(add_query_arg($members_params, $members_url_base)); ?>"
                             class="wt_inline-flex wt_items-center wt_text-primary-600 wt_hover_text-primary-700 underline underline-offset-4">
-                            <?php esc_html_e('Manage Members', 'wicket-acc'); ?>
+                            <?php echo esc_html($manage_members_label); ?>
                         </a>
                     <?php endif; ?>
 

--- a/src/WicketORM/templates-partials/organization-details.php
+++ b/src/WicketORM/templates-partials/organization-details.php
@@ -229,10 +229,26 @@ if ($roster_mode !== 'groups') {
     <?php
     $details_config = \WicketORM\Services\ConfigService::getConfig()['presentation']['organization_details'] ?? [];
 $show_actions = (bool) ($details_config['show_actions'] ?? true);
+
+// Shared action labels (see TemplateHelper::organization_action_label and
+// OrgManConfig presentation.organization_details.labels). Sites can rename
+// "Manage Members" (e.g. "Manage Staff") while the action nav and the
+// organization list cards stay in sync (WWID-2259).
+$org_profile_label = \WicketORM\Helpers\TemplateHelper::organization_action_label('org_profile');
+$manage_members_label = \WicketORM\Helpers\TemplateHelper::organization_action_label('manage_members');
+
+// Mark the action matching the current page as active so the trio behaves as
+// navigation instead of repeated buttons (WWID-2259).
+$current_orgman_path = rtrim((string) parse_url((string) ($_SERVER['REQUEST_URI'] ?? ''), PHP_URL_PATH), '/');
+$is_active_action = static function (string $url) use ($current_orgman_path): bool {
+    $link_path = rtrim((string) parse_url($url, PHP_URL_PATH), '/');
+
+    return $current_orgman_path !== '' && $link_path !== '' && $link_path === $current_orgman_path;
+};
 ?>
 
     <?php if ($show_actions) : ?>
-    <div class="org-details__actions wt_w-full wt_flex wt_items-stretch wt_gap-4 wt_mt-2">
+    <nav class="org-details__actions wt_w-full wt_flex wt_items-stretch wt_gap-4 wt_mt-2" aria-label="<?php esc_attr_e('Organization actions', 'wicket-acc'); ?>">
         <?php
     // Check user permissions for this organization
     if ($roster_mode === 'groups' && $group_uuid !== '') {
@@ -264,23 +280,31 @@ if ($roster_mode === 'groups' && $group_uuid !== '') {
 ?>
 
         <?php if ($can_edit_org): ?>
-            <a href="<?php echo esc_url(add_query_arg($profile_params, $profile_url)); ?>"
-                class="button button--secondary component-button wt_flex-equal wt_inline-flex wt_items-center wt_justify-center wt_text-center"><?php esc_html_e('Org. Profile', 'wicket-acc'); ?></a>
+            <?php $profile_link = add_query_arg($profile_params, $profile_url); ?>
+            <a href="<?php echo esc_url($profile_link); ?>"
+                <?php if ($is_active_action($profile_link)) : ?>aria-current="page"<?php endif; ?>
+                class="button component-button wt_flex-equal wt_inline-flex wt_items-center wt_justify-center wt_text-center <?php echo $is_active_action($profile_link) ? 'button--primary' : 'button--secondary'; ?>"><?php echo esc_html($org_profile_label); ?></a>
         <?php endif; ?>
 
+        <?php $members_link = add_query_arg($members_params, $members_url); ?>
         <?php if ($is_membership_manager): ?>
-            <a href="<?php echo esc_url(add_query_arg($members_params, $members_url)); ?>"
-                class="button button--secondary component-button wt_flex-equal wt_inline-flex wt_items-center wt_justify-center wt_text-center"><?php esc_html_e('Manage Members', 'wicket-acc'); ?></a>
+            <a href="<?php echo esc_url($members_link); ?>"
+                <?php if ($is_active_action($members_link)) : ?>aria-current="page"<?php endif; ?>
+                class="button component-button wt_flex-equal wt_inline-flex wt_items-center wt_justify-center wt_text-center <?php echo $is_active_action($members_link) ? 'button--primary' : 'button--secondary'; ?>"><?php echo esc_html($manage_members_label); ?></a>
         <?php endif; ?>
 
         <?php
         $member_list_config = \WicketORM\Services\ConfigService::getConfig()['presentation']['member_list'] ?? [];
 $show_bulk_upload = (bool) ($member_list_config['show_bulk_upload'] ?? false);
-if ($show_bulk_upload && $can_bulk_upload):
+// Bulk upload is a member-management action: only render it on the members page,
+// never on the org profile page (WWID-2259).
+if ($show_bulk_upload && $can_bulk_upload && $is_active_action($members_link)):
     ?>
-            <a href="<?php echo esc_url(add_query_arg($members_params, $members_bulk_url)); ?>"
-                class="button button--secondary component-button wt_flex-equal wt_inline-flex wt_items-center wt_justify-center wt_text-center"><?php esc_html_e('Bulk Upload', 'wicket-acc'); ?></a>
+            <?php $bulk_link = add_query_arg($members_params, $members_bulk_url); ?>
+            <a href="<?php echo esc_url($bulk_link); ?>"
+                <?php if ($is_active_action($bulk_link)) : ?>aria-current="page"<?php endif; ?>
+                class="button component-button wt_flex-equal wt_inline-flex wt_items-center wt_justify-center wt_text-center <?php echo $is_active_action($bulk_link) ? 'button--primary' : 'button--secondary'; ?>"><?php esc_html_e('Bulk Upload', 'wicket-acc'); ?></a>
         <?php endif; ?>
-    </div>
+    </nav>
     <?php endif; ?>
 </div>

--- a/src/WicketORM/templates-partials/organization-list.php
+++ b/src/WicketORM/templates-partials/organization-list.php
@@ -419,7 +419,7 @@ if ($roster_mode === 'groups') {
                             <span class="wt_px-2 wt_h-4 wt_bg-border-white" aria-hidden="true"></span>
                             <a href="<?php echo esc_url($group_members_manage_url); ?>"
                                 class="wt_inline-flex wt_items-center wt_text-primary-600 wt_hover_text-primary-700 underline underline-offset-4">
-                                <?php esc_html_e('Manage Members', 'wicket-acc'); ?>
+                                <?php echo esc_html(\WicketORM\Helpers\TemplateHelper::organization_action_label('manage_members')); ?>
                             </a>
                         </div>
                     <?php endif; ?>

--- a/src/WicketORM/templates/content-organization-index.php
+++ b/src/WicketORM/templates/content-organization-index.php
@@ -39,6 +39,50 @@ if (empty($org_uuid) && !empty($org_id_fallback)) {
     exit;
 }
 
+// Single-org skip (WWID-2259). When a site opts in and the current user manages
+// exactly one organization, the landing list is one click too many. Redirect
+// straight to that organization: members page for membership managers, profile
+// page for org editors. Users without an actionable role stay on the landing.
+$single_org_skip = (bool) ($orgman_config['presentation']['organization_list']['single_org_skip'] ?? false);
+if ($single_org_skip && $roster_mode !== 'groups' && $org_uuid === '') {
+    $skip_org_service = new \WicketORM\Services\OrganizationService();
+    $skip_user_uuid = wp_get_current_user()->user_login;
+    $skip_organizations = $skip_org_service->getUserOrganizations($skip_user_uuid);
+
+    if (is_array($skip_organizations) && !isset($skip_organizations['error'])) {
+        $skip_organizations = $skip_org_service->filterActiveOrganizations($skip_organizations, $skip_user_uuid);
+
+        if (is_array($skip_organizations) && count($skip_organizations) === 1) {
+            $skip_org = reset($skip_organizations);
+            $skip_org_uuid = (string) ($skip_org['id'] ?? '');
+
+            if ($skip_org_uuid !== '') {
+                $skip_target_url = '';
+
+                if (\WicketORM\Helpers\PermissionHelper::is_membership_manager($skip_org_uuid)) {
+                    $skip_target_url = add_query_arg(
+                        'org_uuid',
+                        $skip_org_uuid,
+                        \WicketORM\Helpers\Helper::getMyAccountPageUrl('organization-members', '/my-account/organization-members/')
+                    );
+                } elseif (\WicketORM\Helpers\PermissionHelper::can_edit_organization($skip_org_uuid)) {
+                    $skip_target_url = add_query_arg(
+                        'org_uuid',
+                        $skip_org_uuid,
+                        \WicketORM\Helpers\Helper::getMyAccountPageUrl('organization-profile', '/my-account/organization-profile/')
+                    );
+                }
+
+                if ($skip_target_url !== '') {
+                    wp_redirect($skip_target_url);
+                    exit;
+                }
+                // No actionable role on the single org: keep the landing page.
+            }
+        }
+    }
+}
+
 ?>
 
 <div id="org-management-index-app" class="org-management-app wicket-orgman wt_w-full wt_mt-6 wt_mb-6">


### PR DESCRIPTION
## Context
Task ID: WWID-2259
Task Link: https://app.asana.com/1/1138832104141584/task/1217469603421297
Related PRs: none

## What
The org-profile and manage-members actions show different wording on the landing cards ("Edit Organization") than on the detail pages ("Org. Profile"). The detail action trio behaves like repeated buttons instead of navigation. Users who manage a single organization pay one extra click on a landing that only lists one card.

## Why
Members read "Edit Organization" and "Org. Profile" as two different destinations, so the action area fails as navigation. The current page action just reloads the page it sits on. For single-org managers the landing adds a click with no information gain; it only helps when a user manages multiple organizations.

## How

### Shared action labels
New config `presentation.organization_details.labels` (`org_profile`, `manage_members`) and `TemplateHelper::organization_action_label()` with stack-default fallback. Landing cards, the groups landing link, and the details action nav render identical wording. Default wording stays "Org. Profile" and "Manage Members"; cards switch from "Edit Organization" to "Org. Profile" for consistency. A site renames the members action like this:

```php
$config['presentation']['organization_details']['labels']['manage_members'] = __('Manage Staff', 'wicket-acc');
```

### Opt-in single-org skip
New config `presentation.organization_list.single_org_skip` (default `false`). When a site opts in and a user manages exactly one organization, the management landing redirects to it: members page for membership managers, profile page for org editors, landing unchanged for users without an actionable role. Non-groups roster modes only. No redirect loop: the skip runs only on the landing without `org_uuid`, and both targets always carry `org_uuid`.

### Behavior notes
- Sites that set nothing new keep working. Visible diffs: the card label swap, and Bulk Upload disappears from profile-shaped views (index with `org_uuid`, profile page) on sites with `show_bulk_upload` enabled. Not limited to the requesting client.
- The skip counts the same org set the landing would render (`getUserOrganizations` + `filterActiveOrganizations`), so it fires only when the landing itself shows a single card. Ambiguous data keeps the landing. `filterActiveOrganizations` is currently a pass-through stub; when it gains real filtering, the skip inherits it.

## Tests
Warden: new `tests/Unit/Roster/Helpers/OrganizationActionLabelsTest.php` (defaults, site rename, blank fallback, nav and aria-current, per-card label usage, skip guard). Updated `GroupsOrganizationDetailsRegressionTest` for the label helper. All pass. Remaining Roster suite failures exist on `main` before this change (verified by stash comparison).
