### PR TITLE
fix(acc): drop dynamic property self-registration in Notification service

### DIFF
--- a/src/Services/Notification.php
+++ b/src/Services/Notification.php
@@ -15,14 +15,6 @@ defined('ABSPATH') || exit;
 class Notification
 {
     /**
-     * Constructor.
-     */
-    public function __construct()
-    {
-        WACC()->Notification = $this;
-    }
-
-    /**
      * Send an email to a user about their team assignment by an organization manager.
      *
      * @param WP_User $user The WordPress user object.


### PR DESCRIPTION
Task: https://app.asana.com/1/1138832104141584/task/1217860503102138

## What changed

Removed the `WACC()->Notification = $this` self-registration from `Notification::__construct()`. The constructor is gone with it (it held nothing else). The service stays reachable through the documented `__call` registry path, `WACC()->Notification()`, fed by `plugin_setup()`.

## Why

The self-assignment created a dynamic property on `WicketAcc`, deprecated since PHP 8.2. It surfaced four times per Warden run of `OrgRosterKillSwitchTest` (every plugin boot instantiates the service). Atlas documents the service locator as method access only; the property form was never part of the contract.

## Risk

Low. Property-form reads of `WACC()->Notification` were searched and found nowhere: stack sources (theme, all plugins), Warden, MDP, and custom code in every client site (themes and mu-plugins). The registry path is untouched.

## Test evidence

- Warden `OrgRosterKillSwitchTest`: 4 passed, 0 deprecated (previously 4 deprecated)
- `php -l` and `composer lint` clean
- No plugin-local tests reference the Notification service