### PR TITLE
fix(orgman): fail closed when direct removal cannot resolve membership #minor

### DIFF
--- a/src/WicketORM/Services/ConnectionService.php
+++ b/src/WicketORM/Services/ConnectionService.php
@@ -721,7 +721,13 @@ class ConnectionService
                 'error_message' => $connections->get_error_message(),
             ]);
 
-            return ['ended' => $ended, 'errors' => $errors];
+            // A failed lookup is not "nothing to end". Returning empty results here
+            // made callers report clean success with unknown connection state, so
+            // fail closed instead (WWID-2360 sibling).
+            return new WP_Error(
+                'connections_query_failed',
+                'Could not list the active connections to end: ' . $connections->get_error_message()
+            );
         }
 
         $normalized_skip_types = $this->normalizeSkipTypes($skip_types);

--- a/src/WicketORM/Services/Strategies/CascadeStrategy.php
+++ b/src/WicketORM/Services/Strategies/CascadeStrategy.php
@@ -557,8 +557,12 @@ class CascadeStrategy implements RosterManagementStrategy
 
             // End every active person-to-organization connection. Continue-on-error sibling;
             // no removal-side skip-types config exists today, so pass an empty allowlist
-            // for exact parity with the current modal behavior.
+            // for exact parity with the current modal behavior. A lookup failure fails
+            // closed; per-record errors continue and are logged below.
             $connection_result = $this->connectionService()->endAllActivePersonOrganizationConnections($person_uuid, $org_id, []);
+            if (is_wp_error($connection_result)) {
+                return new \WP_Error('connection_end_failed', $connection_result->get_error_message());
+            }
             if (!empty($connection_result['errors'])) {
                 $logger->warning('[OrgMan] Cascade strategy ended connections with per-record errors', array_merge($log_context, [
                     'ended_count' => count($connection_result['ended']),

--- a/src/WicketORM/Services/Strategies/DirectAssignmentStrategy.php
+++ b/src/WicketORM/Services/Strategies/DirectAssignmentStrategy.php
@@ -866,7 +866,7 @@ class DirectAssignmentStrategy implements RosterManagementStrategy
 
                     return new WP_Error(
                         'membership_uuid_unresolvable',
-                        'The organization membership record could not be verified, so the removal was cancelled before anything changed. Please try again in a moment; if it keeps failing, the membership may need to be ended manually.'
+                        'The organization membership record could not be verified, so the removal was cancelled before anything changed. Please try again in a moment. If this keeps happening, please contact support.'
                     );
                 }
                 $membership_uuid = $resolved;
@@ -953,11 +953,16 @@ class DirectAssignmentStrategy implements RosterManagementStrategy
             }
 
             // End every active person-to-organization connection (continue-on-error,
-            // cascade parity). Protected types are never touched.
+            // cascade parity). Protected types are never touched. A lookup failure
+            // is not "nothing to end": fail closed so the removal reports an error
+            // instead of silently leaving connections active.
             $protected_types = $config['member_management']['addition']['protected_relationship_types'] ?? [];
             $protected_types = is_array($protected_types) ? $protected_types : [];
 
             $connection_result = $this->connectionService()->endAllActivePersonOrganizationConnections($person_uuid, $org_id, $protected_types);
+            if (is_wp_error($connection_result)) {
+                return new WP_Error('connection_end_failed', $connection_result->get_error_message());
+            }
             if (!empty($connection_result['errors'])) {
                 $this->getLogger()->warning('Direct strategy ended connections with per-record errors', [
                     'source' => 'wicket-orgman',

--- a/src/WicketORM/Services/Strategies/DirectAssignmentStrategy.php
+++ b/src/WicketORM/Services/Strategies/DirectAssignmentStrategy.php
@@ -856,7 +856,20 @@ class DirectAssignmentStrategy implements RosterManagementStrategy
                 $membership_uuid = $resolved;
             } elseif ('' !== $org_id) {
                 $resolved = $this->membershipService()->getOrganizationMembershipUuid($org_id);
-                $membership_uuid = is_string($resolved) && '' !== $resolved ? $resolved : '';
+                if (!is_string($resolved) || '' === $resolved) {
+                    $this->getLogger()->error('Direct strategy could not resolve the org membership for removal', [
+                        'source' => 'wicket-orgman',
+                        'strategy' => 'direct',
+                        'org_id' => $org_id,
+                        'person_uuid' => $person_uuid,
+                    ]);
+
+                    return new WP_Error(
+                        'membership_uuid_unresolvable',
+                        'The organization membership record could not be verified, so the removal was cancelled before anything changed. Please try again in a moment; if it keeps failing, the membership may need to be ended manually.'
+                    );
+                }
+                $membership_uuid = $resolved;
             }
 
             // Validate the row-level person membership against the resolved org


### PR DESCRIPTION
## Context
Task ID: WWID-2360
Task Link: https://app.asana.com/1/1138832104141584/task/1217949441159657
Related PRs: wicket-warden#12 (merged)

## What
Direct roster removal now aborts with a clear error when the organization membership cannot be resolved, instead of silently completing without ending the membership. The connection-ending step gets the same treatment: a failed connection lookup aborts instead of reporting success with unknown connection state.

## Why
The WWID-2219 fix resolved the org membership through a fallback lookup when the removal request carried no membership uuid. A null or empty result silently skipped the whole membership-end block while roles and connections still changed and the action reported success. A transient MDP lookup failure could therefore reproduce the original symptom on fixed code: the person keeps an active membership and a consumed seat. The peer review of that fix flagged the connection lookup as the same failure class one layer down; this PR closes both.

## How
- The fallback branch fails closed before any mutation and returns `membership_uuid_unresolvable` with a retry message and a support escalation path.
- The context-supplied membership uuid branch keeps its existing fail-closed handling.
- `ConnectionService::endAllActivePersonOrganizationConnections()` now returns `connections_query_failed` on a lookup failure; Direct and Cascade propagate it as `connection_end_failed`. Per-record end errors keep the existing continue-on-error behavior. Memberships and roles end before connections in both strategies, so a retry recovers: the earlier steps are idempotent.
- This intentionally retires the connection-only contract for unresolvable lookups. Connection-only removals still work whenever the org membership resolves; the sweep then finds nothing to end. The roster UI cannot reach the unresolvable state for membership-less orgs, because the members list is membership-driven.
- Blast radius: Cascade and MembershipCycle already require a caller-supplied membership uuid and fail closed; GroupsStrategy is group-scoped; no batch callers exist.

## Testing
- [x] New regression tests: fail-closed abort on both intake shapes (connection_id and person_membership_id), the resolvable connection-only path, and the connection lookup failure in both strategies and the service.
- [x] Repaired stale owner-guard stubs that predated the cascade membership validation (masked by the test runner's fail-fast exit).
- [x] `wicket test unit:account-centre` (with the warden test updates): 527 registered, 527 passed, 0 failed.