### PR TITLE
fix(orgman): run bulk upload batches as the acting user

### DIFF
--- a/src/WicketORM/Services/BulkMemberUploadService.php
+++ b/src/WicketORM/Services/BulkMemberUploadService.php
@@ -73,6 +73,22 @@ class BulkMemberUploadService
         string $roster_mode,
         string $group_uuid = ''
     ) {
+        // The batch worker impersonates this user (see processScheduledJob):
+        // cron context has no logged-in user, so the job must carry who to
+        // run as. Fail closed rather than queueing a job that can only fail
+        // per-row with "no permission".
+        $acting_user_id = get_current_user_id();
+        if ($acting_user_id <= 0) {
+            $this->logActivity('error', 'Bulk upload enqueue failed: no acting user', [
+                'file_name' => $file_name,
+                'org_uuid' => $org_uuid,
+                'membership_uuid' => $membership_uuid,
+                'roster_mode' => $roster_mode,
+            ]);
+
+            return new WP_Error('bulk_no_acting_user', __('Unable to determine the uploading user.', 'wicket-acc'));
+        }
+
         $config = $this->configService->getFullConfig();
         $bulk_upload_config = is_array($config['member_management']['bulk_upload'] ?? null)
             ? $config['member_management']['bulk_upload']
@@ -203,23 +219,46 @@ class BulkMemberUploadService
                     );
                 }
 
-                $this->logActivity('warning', 'Bulk upload enqueue blocked: duplicate file already processed', [
+                // A finished job only blocks re-upload when nothing was left
+                // undone: every row resolved without a failure (added or
+                // legitimately skipped). Jobs whose rows failed must be
+                // retryable with the same file: that is how a membership
+                // manager recovers from a bad run without editing the CSV.
+                // Rows already added are skipped as existing members.
+                $existing_added = (int) ($existing_job['added'] ?? 0);
+                $existing_total = (int) ($existing_job['total_records'] ?? 0);
+                $existing_failed = (int) ($existing_job['failed'] ?? 0);
+                $existing_processed = (int) ($existing_job['processed'] ?? 0);
+                if ($existing_failed === 0 && $existing_processed >= $existing_total) {
+                    $this->logActivity('warning', 'Bulk upload enqueue blocked: duplicate file already processed', [
+                        'existing_job_id' => $existing_job_id,
+                        'existing_status' => $existing_status,
+                        'file_name' => $file_name,
+                        'file_sha256' => $file_sha256,
+                        'org_uuid' => $org_uuid,
+                        'membership_uuid' => $membership_uuid,
+                    ]);
+
+                    return new WP_Error(
+                        'bulk_duplicate_finished_job',
+                        sprintf(
+                            __('This exact same CSV was already processed before (matching file hash). Existing job: %1$s (status: %2$s). Please upload a different CSV with different users.', 'wicket-acc'),
+                            $existing_job_id,
+                            $existing_status
+                        )
+                    );
+                }
+
+                $this->logActivity('info', 'Bulk upload enqueue allowed: retrying incomplete duplicate file', [
                     'existing_job_id' => $existing_job_id,
                     'existing_status' => $existing_status,
+                    'existing_added' => $existing_added,
+                    'existing_total' => $existing_total,
                     'file_name' => $file_name,
                     'file_sha256' => $file_sha256,
                     'org_uuid' => $org_uuid,
                     'membership_uuid' => $membership_uuid,
                 ]);
-
-                return new WP_Error(
-                    'bulk_duplicate_finished_job',
-                    sprintf(
-                        __('This exact same CSV was already processed before (matching file hash). Existing job: %1$s (status: %2$s). Please upload a different CSV with different users.', 'wicket-acc'),
-                        $existing_job_id,
-                        $existing_status
-                    )
-                );
             }
         }
 
@@ -237,6 +276,7 @@ class BulkMemberUploadService
             'membership_uuid' => $membership_uuid,
             'roster_mode' => $roster_mode,
             'group_uuid' => $group_uuid,
+            'acting_user_id' => $acting_user_id,
             'total_records' => count($rows),
             'processed' => 0,
             'added' => 0,
@@ -266,6 +306,9 @@ class BulkMemberUploadService
             $job['status'] = 'failed';
             $job['updated_at'] = $this->nowIso8601();
             $this->appendErrorSnippet($job, __('Unable to schedule background processing.', 'wicket-acc'));
+            // Do not keep the full CSV payload in options for a dead job.
+            $job['rows'] = [];
+            $job['seen_emails'] = [];
             $this->saveJob($job);
             $this->logActivity('error', 'Bulk upload job queue failed: unable to schedule first batch', [
                 'job_id' => $job_id,
@@ -300,6 +343,54 @@ class BulkMemberUploadService
         if ($status === 'completed' || $status === 'failed') {
             return;
         }
+
+        // Cron workers run with no logged-in user, and the per-strategy
+        // permission gates (PermissionHelper::role_check,
+        // GroupService::canManageGroup) resolve the acting member from the
+        // current user. Run the batch as the uploader captured at enqueue so
+        // those gates evaluate the real member. wp-cron can process several
+        // due hooks in one request: the finally guarantees a thrown error
+        // cannot leak the impersonated identity to a later hook.
+        $acting_user_id = (int) ($job['acting_user_id'] ?? 0);
+        $previous_user_id = get_current_user_id();
+        if ($acting_user_id > 0 && get_userdata($acting_user_id) !== false) {
+            wp_set_current_user($acting_user_id);
+        } else {
+            $this->logActivity('warning', 'Bulk upload batch has no resolvable acting user; permission checks will fail closed', [
+                'job_id' => $job_id,
+                'acting_user_id' => $acting_user_id,
+            ]);
+        }
+
+        // Second line of defense for the impersonation: finally{} below does
+        // not run on exit()/die() (wp_die), and wp-cron processes all due
+        // hooks in one request. Core's shutdown action still fires on those
+        // paths, so restore there too. Must be registered BEFORE the batch:
+        // a fatal mid-batch never reaches code placed after it.
+        add_action('shutdown', static function () use ($acting_user_id, $previous_user_id): void {
+            if ($acting_user_id > 0 && get_current_user_id() === $acting_user_id) {
+                wp_set_current_user($previous_user_id);
+            }
+        });
+
+        try {
+            $this->runBatch($job, $status);
+        } finally {
+            wp_set_current_user($previous_user_id);
+        }
+    }
+
+    /**
+     * Process one batch for an in-progress job. Called by processScheduledJob
+     * under the acting user's identity; all state changes persist via saveJob().
+     *
+     * @param array<string, mixed> $job
+     * @param string               $status Job status before this batch started.
+     * @return void
+     */
+    private function runBatch(array $job, string $status): void
+    {
+        $job_id = (string) ($job['id'] ?? '');
 
         $job['status'] = 'processing';
         $job['updated_at'] = $this->nowIso8601();
@@ -625,6 +716,9 @@ class BulkMemberUploadService
             $job['status'] = 'failed';
             $job['updated_at'] = $this->nowIso8601();
             $this->appendErrorSnippet($job, __('Unable to schedule next background batch.', 'wicket-acc'));
+            // Do not keep the full CSV payload in options for a dead job.
+            $job['rows'] = [];
+            $job['seen_emails'] = [];
             $this->saveJob($job);
             $this->logActivity('error', 'Bulk upload job failed: unable to schedule next batch', [
                 'job_id' => (string) ($job['id'] ?? ''),
@@ -646,6 +740,9 @@ class BulkMemberUploadService
         return [
             'id' => (string) ($job['id'] ?? ''),
             'status' => (string) ($job['status'] ?? ''),
+            'org_uuid' => (string) ($job['org_uuid'] ?? ''),
+            'group_uuid' => (string) ($job['group_uuid'] ?? ''),
+            'roster_mode' => (string) ($job['roster_mode'] ?? ''),
             'file_name' => (string) ($job['file_name'] ?? ''),
             'file_sha256' => (string) ($job['file_sha256'] ?? ''),
             'created_at' => (string) ($job['created_at'] ?? ''),


### PR DESCRIPTION
https://app.asana.com/1/1138832104141584/task/1216917808856765

Bulk upload cron batches ran with no logged-in user, so every row failed the strategy permission gates ("no permission to add members") while the job still completed. Membership managers saw a success message and the roster never changed. Live-reproduced on ESCRS staging: every queued job completed with added=0, failed=N and the same permission error on all rows.

What changed:
- capture acting_user_id at enqueue and refuse to queue without one
- impersonate the acting user for the whole batch; restore in a finally plus a shutdown guard for die()/wp_die() paths (wp-cron processes all due hooks in one request)
- allow re-uploading the same CSV unless every row resolved without failure, so rosters that failed can be retried as-is (rows already added skip as existing members)
- drop the CSV payload from options when a job dies unscheduled
- expose org/group/mode on job status for scoped status checks (used by the polling PR that stacks on this one)

Groups-mode sites were silently affected too: GroupService::canManageGroup() resolves from the current user and fails the same way in cron.

Tests: Warden `composer test:unit:account-centre` green (521 passed). New coverage: acting-user capture, impersonate/restore sequence, ghost-user fail-closed, shutdown guard ordering (mutation-tested), retry rules (all-failed/partial allow, all-skipped and full-success block), CSV payload cleanup on both schedule-failure branches.

Peer-reviewed (isolated Claude review, two rounds, all blockers resolved).