### PR TITLE
feat(orgman): poll bulk upload job status from the upload modal

### DIFF
--- a/src/WicketORM/Controllers/ApiController.php
+++ b/src/WicketORM/Controllers/ApiController.php
@@ -160,4 +160,30 @@ abstract class ApiController
     {
         return $this->htmlResponse(['success' => false, 'error' => ['code' => $error_code, 'message' => $error_message]], $status);
     }
+
+    /**
+     * Render a templates-partials file into an HTML REST response.
+     * Variables in $data are extracted into the partial's scope.
+     *
+     * @param string $template Template name relative to templates-partials/.
+     * @param array  $data     Variables for the partial.
+     * @return \WP_REST_Response
+     */
+    protected function templateResponse(string $template, array $data): \WP_REST_Response
+    {
+        ob_start();
+        if (!empty($data)) {
+            extract($data);
+        }
+        $template_path = dirname(dirname(__FILE__)) . '/templates-partials/' . $template . '.php';
+        if (file_exists($template_path)) {
+            include $template_path;
+        }
+        $html = ob_get_clean();
+
+        $response = new \WP_REST_Response($html);
+        $response->header('Content-Type', 'text/html');
+
+        return $response;
+    }
 }

--- a/src/WicketORM/Controllers/BulkUploadController.php
+++ b/src/WicketORM/Controllers/BulkUploadController.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * Bulk upload controller.
+ */
+
+namespace WicketORM\Controllers;
+
+use WicketORM\Services\BulkMemberUploadService;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Handles REST routes for the CSV bulk member upload.
+ */
+class BulkUploadController extends ApiController
+{
+    /**
+     * @var BulkMemberUploadService
+     */
+    private $bulk_upload_service;
+
+    /**
+     * @param BulkMemberUploadService $bulk_upload_service
+     */
+    public function __construct(BulkMemberUploadService $bulk_upload_service)
+    {
+        $this->bulk_upload_service = $bulk_upload_service;
+        $this->namespace = 'wicket-acc/v1/bulk-upload';
+    }
+
+    /**
+     * Register REST routes.
+     */
+    public function registerRoutes()
+    {
+        register_rest_route($this->namespace, '/status', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [$this, 'getBulkUploadStatus'],
+                'permission_callback' => [$this, 'checkLoggedIn'],
+            ],
+        ]);
+    }
+
+    /**
+     * Return the current status of a bulk upload job as HTML.
+     *
+     * Access is scoped to the same right that created the job: org-level
+     * add-member permission for seat strategies, group management for groups
+     * mode. Anything inconclusive fails closed with an empty 403 so the job's
+     * existence does not leak (mirrors the member export status endpoint).
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response
+     */
+    public function getBulkUploadStatus(WP_REST_Request $request)
+    {
+        $job_id = sanitize_key($request->get_param('job_id'));
+
+        if (empty($job_id)) {
+            return new WP_REST_Response('', 200);
+        }
+
+        $status = $this->bulk_upload_service->getJobStatus($job_id);
+
+        if (!is_array($status)) {
+            // Unknown or pruned job: render the stop-poll notice (no job
+            // details) so the modal's poller halts instead of spinning. The
+            // suffix comes from the poller itself; it only names the signal
+            // to flip and authorizes nothing.
+            return $this->templateResponse('bulk-upload-status', [
+                'job_id' => $job_id,
+                'status' => null,
+                'signal_suffix' => sanitize_key((string) $request->get_param('suffix')),
+            ]);
+        }
+
+        if (!self::currentUserCanViewJobStatus($status)) {
+            return new WP_REST_Response('', 403);
+        }
+
+        return $this->templateResponse('bulk-upload-status', [
+            'job_id' => $job_id,
+            'status' => $status,
+            'signal_suffix' => self::statusSignalSuffix($status),
+        ]);
+    }
+
+    /**
+     * Whether the current user may see a job's status.
+     *
+     * Mirrors the enqueue-time gate in process/bulk-upload-members.php: seat
+     * strategies check org-level add-member permission, groups mode checks
+     * group management (a distinct role model — an org-level membership
+     * manager is not automatically every group's manager). Empty identifiers
+     * fail closed.
+     *
+     * @param array<string, mixed> $status Job status payload.
+     * @return bool
+     */
+    public static function currentUserCanViewJobStatus(array $status): bool
+    {
+        $roster_mode = (string) ($status['roster_mode'] ?? '');
+        $org_uuid = (string) ($status['org_uuid'] ?? '');
+        $group_uuid = (string) ($status['group_uuid'] ?? '');
+
+        if ($roster_mode === 'groups') {
+            if ($group_uuid === '') {
+                return false;
+            }
+
+            $current_user = wp_get_current_user();
+            $manager_uuid = $current_user ? (string) $current_user->user_login : '';
+            $access = (new \WicketORM\Services\GroupService())->canManageGroup($group_uuid, $manager_uuid);
+
+            return !empty($access['allowed']);
+        }
+
+        if ($org_uuid === '') {
+            return false;
+        }
+
+        return \WicketORM\Helpers\PermissionHelper::can_add_members($org_uuid);
+    }
+
+    /**
+     * Signal suffix for the status partial, mirroring the polling modal's
+     * three-way DOM suffix (org_uuid -> group_uuid -> 'default') so the
+     * terminal stop-signal patch flips the signal the modal actually reads.
+     *
+     * @param array<string, mixed> $status Job status payload.
+     * @return string
+     */
+    public static function statusSignalSuffix(array $status): string
+    {
+        $dom_suffix_raw = (string) ($status['org_uuid'] ?? '');
+        if ($dom_suffix_raw === '') {
+            $dom_suffix_raw = (string) ($status['group_uuid'] ?? '');
+        }
+        if ($dom_suffix_raw === '') {
+            $dom_suffix_raw = 'default';
+        }
+
+        return str_replace('-', '_', sanitize_key($dom_suffix_raw));
+    }
+}

--- a/src/WicketORM/Controllers/MemberExportController.php
+++ b/src/WicketORM/Controllers/MemberExportController.php
@@ -210,25 +210,14 @@ class MemberExportController extends ApiController
     }
 
     /**
+     * Render a partial template as an HTML response.
+     *
      * @param string $template
      * @param array  $data
      * @return WP_REST_Response
      */
     private function htmlResponse(string $template, array $data): WP_REST_Response
     {
-        ob_start();
-        if (!empty($data)) {
-            extract($data);
-        }
-        $template_path = dirname(dirname(__FILE__)) . '/templates-partials/' . $template . '.php';
-        if (file_exists($template_path)) {
-            include $template_path;
-        }
-        $html = ob_get_clean();
-
-        $response = new WP_REST_Response($html);
-        $response->header('Content-Type', 'text/html');
-
-        return $response;
+        return $this->templateResponse($template, $data);
     }
 }

--- a/src/WicketORM/OrgMan.php
+++ b/src/WicketORM/OrgMan.php
@@ -149,6 +149,10 @@ final class OrgMan
             $this->controllers['member_export'] = new Controllers\MemberExportController($this->services['member_export']);
         }
 
+        if (isset($this->services['bulk_upload'])) {
+            $this->controllers['bulk_upload'] = new Controllers\BulkUploadController($this->services['bulk_upload']);
+        }
+
         if (isset($this->services['engagement'])) {
             $this->controllers['engagement'] = new Controllers\EngagementController($this->services['engagement']);
         }

--- a/src/WicketORM/templates-partials/bulk-upload-status.php
+++ b/src/WicketORM/templates-partials/bulk-upload-status.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Bulk upload job status partial. Polled via REST from the upload modal.
+ *
+ * Variables:
+ *   $job_id (string)
+ *   $status (array|null) from BulkMemberUploadService::getJobStatus()
+ *   $signal_suffix (string) safe suffix matching the polling modal's signals
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$job_id = isset($job_id) ? sanitize_key((string) $job_id) : '';
+$status = isset($status) && is_array($status) ? $status : null;
+$signal_suffix = isset($signal_suffix) ? preg_replace('/[^a-z0-9_]/', '', (string) $signal_suffix) : '';
+$finished_signal = 'bulkUploadFinished' . $signal_suffix;
+
+/**
+ * Terminal states swap in a signal patch that stops the modal's poll, so the
+ * interval does not run forever on a finished (or vanished) job.
+ */
+$stop_poll = static function () use ($finished_signal): string {
+    return '<span data-signals="{ \'' . esc_attr($finished_signal) . '\': true }" class="wt_hidden" aria-hidden="true"></span>';
+};
+
+if ($status === null || $job_id === '') {
+    // Job pruned or unknown. Say so and stop polling; the retry path is a
+    // fresh upload of the same file (allowed unless every row was added).
+    echo '<div class="wt_text-sm wt_text-content wt_mb-3">'
+        . esc_html__('This upload job is no longer available. If the roster did not update, please upload the CSV again.', 'wicket-acc')
+        . $stop_poll()
+        . '</div>';
+
+    return;
+}
+
+$state = (string) ($status['status'] ?? '');
+$total = (int) ($status['total_records'] ?? 0);
+$processed = (int) ($status['processed'] ?? 0);
+$added = (int) ($status['added'] ?? 0);
+$skipped = (int) ($status['skipped'] ?? 0);
+$failed = (int) ($status['failed'] ?? 0);
+$updated_at = (string) ($status['updated_at'] ?? '');
+
+// WP-Cron is request-triggered; on a quiet site a batch can wait. After ten
+// minutes without movement, say so instead of implying active progress.
+$stale = in_array($state, ['queued', 'processing'], true)
+    && $updated_at !== ''
+    && (time() - (int) strtotime($updated_at)) > 600;
+?>
+
+<div class="orgman-bulk-upload-status">
+    <?php if ($state === 'completed') : ?>
+        <?php
+        get_component('alert', [
+            'classes' => ['wt_bg-green-100', 'wt_border', 'wt_border-green-400', 'wt_text-green-700'],
+            'content' => esc_html(
+                sprintf(
+                    /* translators: 1: number added, 2: number skipped, 3: number failed */
+                    __('Bulk upload complete — %1$d added, %2$d skipped, %3$d failed.', 'wicket-acc'),
+                    $added,
+                    $skipped,
+                    $failed
+                )
+            ),
+        ]);
+
+        if ($failed > 0 && !empty($status['error_snippets'])) :
+            echo '<ul class="wt_list-disc wt_pl-5 wt_text-sm wt_text-content wt_mt-1">';
+            foreach (array_slice((array) $status['error_snippets'], 0, 5) as $snippet) {
+                echo '<li>' . esc_html((string) $snippet) . '</li>';
+            }
+            echo '</ul>';
+        endif;
+
+        echo $stop_poll();
+        ?>
+    <?php elseif ($state === 'failed') : ?>
+        <?php
+        get_component('alert', [
+            'classes' => ['wt_bg-red-100', 'wt_border', 'wt_border-red-400', 'wt_text-red-700'],
+            'content' => esc_html__('Bulk upload failed. Please upload the CSV again or contact support.', 'wicket-acc'),
+        ]);
+
+        echo $stop_poll();
+        ?>
+    <?php elseif (in_array($state, ['queued', 'processing'], true)) : ?>
+        <?php
+        get_component('alert', [
+            'classes' => ['wt_bg-blue-100', 'wt_border', 'wt_border-blue-400', 'wt_text-blue-700'],
+            'content' => esc_html(
+                $stale
+                    ? sprintf(
+                        /* translators: 1: rows processed, 2: total rows */
+                        __('Still working — %1$d of %2$d row(s) processed. This is taking longer than expected; you can leave this page and check the roster later.', 'wicket-acc'),
+                        $processed,
+                        $total
+                    )
+                    : sprintf(
+                        /* translators: 1: rows processed, 2: total rows */
+                        __('Bulk upload in progress — %1$d of %2$d row(s) processed…', 'wicket-acc'),
+                        $processed,
+                        $total
+                    )
+            ),
+        ]);
+        ?>
+    <?php else : ?>
+        <?php
+        // Unknown state: stop polling rather than spin forever.
+        echo '<div class="wt_text-sm wt_text-content wt_mb-3">'
+            . esc_html__('This upload job is in an unknown state. If the roster did not update, please upload the CSV again.', 'wicket-acc')
+            . $stop_poll()
+            . '</div>';
+        ?>
+    <?php endif; ?>
+</div>

--- a/src/WicketORM/templates-partials/members-bulk-upload.php
+++ b/src/WicketORM/templates-partials/members-bulk-upload.php
@@ -56,6 +56,22 @@ foreach ($default_bulk_columns as $column_key => $defaults) {
     $expected_columns[] = (string) ($column_config['header'] ?? $defaults['header']);
 }
 $expected_columns_text = implode(', ', $expected_columns);
+
+// Job-status polling (WWID-1919): the upload response sets the job id signal,
+// a 3s interval polls the REST status endpoint until the partial reports a
+// terminal state (the partial swaps in the finished-signal patch itself).
+// Signals are global per page, so they carry the same DOM suffix the export
+// flow uses to keep two roster views from colliding.
+$bulk_upload_signal_suffix = str_replace('-', '_', sanitize_key($bulk_upload_dom_suffix_raw));
+$bulk_upload_job_signal = 'bulkUploadJobId' . $bulk_upload_signal_suffix;
+$bulk_upload_finished_signal = 'bulkUploadFinished' . $bulk_upload_signal_suffix;
+$bulk_upload_status_url = rest_url('wicket-acc/v1/bulk-upload/status');
+// Cookie-authenticated REST requests need the wp_rest nonce on every call,
+// GET included (same as the export modal's POST).
+$bulk_upload_rest_nonce = wp_create_nonce('wp_rest');
+$bulk_upload_poll = "if (!{$bulk_upload_finished_signal} && {$bulk_upload_job_signal} !== '') { @get('"
+    . $bulk_upload_status_url . "?job_id=' + {$bulk_upload_job_signal} + '&suffix={$bulk_upload_signal_suffix}',"
+    . " { headers: {'X-WP-Nonce': '{$bulk_upload_rest_nonce}'} }) >> select('#{$bulk_upload_messages_id}') | set(html) }";
 ?>
 
 <div class="orgman-bulk-upload <?php echo esc_attr($bulk_upload_wrapper_class); ?>">
@@ -64,7 +80,9 @@ $expected_columns_text = implode(', ', $expected_columns);
         <?php esc_html_e('Upload a CSV file to add multiple members at once. Existing active members are skipped automatically.', 'wicket-acc'); ?>
     </p>
 
-    <div id="<?php echo esc_attr($bulk_upload_messages_id); ?>" class="wt_mb-3"></div>
+    <div id="<?php echo esc_attr($bulk_upload_messages_id); ?>" class="wt_mb-3"
+        data-signals="<?php echo esc_attr(wp_json_encode([$bulk_upload_job_signal => '', $bulk_upload_finished_signal => true])); ?>"
+        data-on-interval__duration.3000="<?php echo esc_attr($bulk_upload_poll); ?>"></div>
 
     <div class="wt_mb-3">
         <a class="orgman-bulk-upload__template-link wt_text-sm"

--- a/src/WicketORM/templates-partials/process/bulk-upload-members.php
+++ b/src/WicketORM/templates-partials/process/bulk-upload-members.php
@@ -177,10 +177,16 @@ $summary = sprintf(
 );
 $summary .= '<br>' . esc_html__('Processing runs in the background with WordPress Cron.', 'wicket-acc');
 
+// Hand the job to the modal's poller: same suffixed signals the modal
+// declared (mirrors the export flow's suffix transform).
+$safe_suffix = str_replace('-', '_', sanitize_key($org_dom_suffix));
+
 status_header(200);
 WicketORM\Helpers\DatastarSSE::renderSuccess($summary, $message_target, [
     'membersLoading' => false,
     'bulkUploadSubmitting' => false,
+    'bulkUploadJobId' . $safe_suffix => $job_id,
+    'bulkUploadFinished' . $safe_suffix => false,
 ], 0, 'bulk-upload-countdown');
 
 return;


### PR DESCRIPTION
https://app.asana.com/1/1138832104141584/task/1216917808856765

Stacks on #41 (needs its service changes). The upload modal reported "queued" forever: jobs processed, or failed every row, with no surface for the outcome. That was half of the ESCRS bug report (success message, roster never changed, nobody told the user).

What changed:
- new BulkUploadController: GET wicket-acc/v1/bulk-upload/status, scoped to the same right that created the job (org add-members, or group management in groups mode), fail closed with an empty 403 so job existence never leaks
- status partial renders progress, then an added/skipped/failed summary with capped per-row errors; terminal states swap in the finished signal so the modal poll stops
- upload modal declares suffixed job signals (same suffix convention as the export flow) and polls every 3s with the wp_rest nonce header; the enqueue response hands over the job id
- stale jobs (>10 min without movement) say "taking longer than expected" instead of implying progress
- extract templateResponse() into ApiController; the export status route now delegates to it

Note for reviewers: after #41 merges, GitHub should retarget this to main automatically.

Tests: Warden `composer test:unit:account-centre` green. New coverage: suffix parity with the modal (org -> group -> default), fail-closed 403s for context-less payloads, stop-poll rendering for pruned jobs, completion summary with capped error list.

Peer-reviewed (isolated Claude review, two rounds: caught the missing wp_rest nonce, the groups-mode suffix divergence, and a fail-open scoping check; all fixed and re-verified).