### PR TITLE
feat(admin): add required account center pages notice

### DIFF
--- a/class-wicket-acc-main.php
+++ b/class-wicket-acc-main.php
@@ -4,6 +4,7 @@ namespace WicketAcc;
 
 use WicketAcc\Admin\AdminSettings;
 use WicketAcc\Admin\HFMigration;
+use WicketAcc\Admin\RequiredPagesNotice;
 use WicketAcc\Admin\Safeguards;
 use WicketAcc\Admin\Tweaks;
 use WicketAcc\Mdp\Init as Mdp;
@@ -439,6 +440,7 @@ class WicketAcc
             new AdminSettings();
             new Tweaks();
             new Safeguards(); // Initialize the safeguard class for admin tasks and CLI
+            new RequiredPagesNotice(); // Warn when org-roster account pages are missing (WWID-1919)
         }
 
         // Load WooCommerce integration if active

--- a/src/Admin/RequiredPagesNotice.php
+++ b/src/Admin/RequiredPagesNotice.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WicketAcc\Admin;
+
+// No direct access
+defined('ABSPATH') || exit;
+
+/**
+ * Surfaces missing my-account pages that the org-roster UI links to.
+ *
+ * Helper::getMyAccountPageUrl() falls back to a home_url() path when a slug
+ * has no post, and that fallback 404s (WWID-1919: ESCRS "Bulk Upload" button).
+ * docs/ORM/product/SETUP.md "Required WordPress Pages" documents the slugs,
+ * but nothing checked them, so the break was silent until a user clicked.
+ *
+ * The notice lists the missing slugs and offers an explicit button to create
+ * them. Nothing is created automatically: a site may deliberately rename or
+ * omit a slug (WPML, custom flows), so creation stays in admin hands.
+ */
+class RequiredPagesNotice extends \WicketAcc\WicketAcc
+{
+    /**
+     * Slug => default page title. Mirrors docs/ORM/product/SETUP.md
+     * "Required WordPress Pages". Conditional slugs are removed per config in
+     * requiredPages().
+     *
+     * @var array<string, string>
+     */
+    private const PAGE_TITLES = [
+        'organization-management' => 'Organization Management',
+        'organization-profile' => 'Organization Profile',
+        'organization-members' => 'Organization Members',
+        'organization-members-bulk' => 'Organization Members Bulk Upload',
+        'supplemental-members' => 'Purchase Additional Seats',
+        'organization-contacts' => 'Organization Contacts',
+    ];
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        add_action('admin_notices', [$this, 'renderNotice']);
+        add_action('admin_post_wicket_acc_create_required_pages', [$this, 'handleCreate']);
+    }
+
+    /**
+     * Slugs that apply to this site right now, slug => page title.
+     *
+     * A page only counts as required when the feature linking to it is on:
+     * the bulk-upload button renders only with show_bulk_upload, and the
+     * contacts page only with contacts.enabled.
+     *
+     * @return array<string, string>
+     */
+    public function requiredPages(): array
+    {
+        $config = \WicketORM\Services\ConfigService::getConfig();
+
+        $required = self::PAGE_TITLES;
+
+        if (empty($config['presentation']['member_list']['show_bulk_upload'])) {
+            unset($required['organization-members-bulk']);
+        }
+
+        if (empty($config['contacts']['enabled'])) {
+            unset($required['organization-contacts']);
+        }
+
+        // Tenants that deliberately renamed or dropped a slug can filter it
+        // out here instead of living with a permanent notice.
+        return apply_filters('wicket_acc/required-pages/slugs', $required);
+    }
+
+    /**
+     * Required slugs with no published my-account page.
+     *
+     * Mirrors Helper::getMyAccountPageUrl(): it looks up published posts
+     * (get_posts default status), so a draft or trash page still counts as
+     * missing here.
+     *
+     * @return array<string, string> slug => title
+     */
+    public function missingPages(): array
+    {
+        $missing = [];
+
+        foreach ($this->requiredPages() as $slug => $title) {
+            $existing = get_posts([
+                'post_type' => 'my-account',
+                'name' => $slug,
+                'numberposts' => 1,
+                'fields' => 'ids',
+            ]);
+
+            if (empty($existing)) {
+                $missing[$slug] = $title;
+            }
+        }
+
+        return $missing;
+    }
+
+    /**
+     * Create a published my-account page per missing slug.
+     *
+     * @return array<string, int|\WP_Error> slug => new post ID or error
+     */
+    public function createMissingPages(): array
+    {
+        $created = [];
+
+        foreach ($this->missingPages() as $slug => $title) {
+            $created[$slug] = wp_insert_post([
+                'post_type' => 'my-account',
+                'post_status' => 'publish',
+                'post_title' => $title,
+                'post_name' => $slug,
+            ], true);
+        }
+
+        return $created;
+    }
+
+    /**
+     * Admin notice listing missing pages with a create button.
+     *
+     * @return void
+     */
+    public function renderNotice(): void
+    {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        $created = isset($_GET['wicket_acc_pages_created']) ? absint($_GET['wicket_acc_pages_created']) : null;
+        $failed = isset($_GET['wicket_acc_pages_failed']) ? absint($_GET['wicket_acc_pages_failed']) : 0;
+        if ($created !== null) {
+            if ($failed > 0) {
+                printf(
+                    '<div class="notice notice-warning is-dismissible"><p>%s</p></div>',
+                    esc_html(sprintf(
+                        /* translators: 1: number created, 2: number failed. */
+                        __('Account Centre: created %1$d page(s), %2$d could not be created. Check the Account Centre page list for details.', 'wicket-acc'),
+                        $created,
+                        $failed
+                    ))
+                );
+            } else {
+                printf(
+                    '<div class="notice notice-success is-dismissible"><p>%s</p></div>',
+                    esc_html(sprintf(
+                        /* translators: %d: number of pages created. */
+                        __('Account Centre: created %d missing page(s).', 'wicket-acc'),
+                        $created
+                    ))
+                );
+            }
+        }
+
+        $missing = $this->missingPages();
+        if (empty($missing)) {
+            return;
+        }
+
+        $slug_list = implode(
+            ', ',
+            array_map(static fn (string $slug): string => '<code>' . esc_html($slug) . '</code>', array_keys($missing))
+        );
+        ?>
+        <div class="notice notice-error">
+            <p>
+                <strong><?php esc_html_e('Account Centre: missing account pages.', 'wicket-acc'); ?></strong>
+                <?php
+                printf(
+                    /* translators: %s: comma-separated list of page slugs. */
+                    esc_html__('The Account Centre links to account pages that do not exist on this site, so those links lead to a 404. Missing: %s', 'wicket-acc'),
+                    wp_kses_post($slug_list)
+                );
+        ?>
+            </p>
+            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="padding-bottom: 8px;">
+                <input type="hidden" name="action" value="wicket_acc_create_required_pages">
+                <?php wp_nonce_field('wicket_acc_create_required_pages'); ?>
+                <input type="hidden" name="_wp_http_referer" value="<?php echo esc_url($_SERVER['REQUEST_URI'] ?? ''); ?>">
+                <button type="submit" class="button button-primary">
+                    <?php esc_html_e('Create missing pages', 'wicket-acc'); ?>
+                </button>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * admin_post handler for the create button.
+     *
+     * @return void
+     */
+    public function handleCreate(): void
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die(esc_html__('You are not allowed to create Account Centre pages.', 'wicket-acc'));
+        }
+
+        check_admin_referer('wicket_acc_create_required_pages');
+
+        $results = $this->createMissingPages();
+
+        $created = 0;
+        $failed = 0;
+        foreach ($results as $result) {
+            if (is_wp_error($result)) {
+                $failed++;
+                continue;
+            }
+
+            $created++;
+        }
+
+        $redirect = wp_get_referer() ?: admin_url();
+        wp_safe_redirect(add_query_arg([
+            'wicket_acc_pages_created' => $created,
+            'wicket_acc_pages_failed' => $failed,
+        ], $redirect));
+        exit;
+    }
+}

--- a/src/Admin/RequiredPagesNotice.php
+++ b/src/Admin/RequiredPagesNotice.php
@@ -38,6 +38,13 @@ class RequiredPagesNotice extends \WicketAcc\WicketAcc
     ];
 
     /**
+     * Guards createMissingPages() against concurrent runs (double-click,
+     * two admins). Short TTL so a crashed request cannot leave a
+     * permanent lock.
+     */
+    private const CREATE_LOCK_TRANSIENT = 'wicket_acc_create_required_pages_lock';
+
+    /**
      * Constructor.
      */
     public function __construct()
@@ -106,22 +113,40 @@ class RequiredPagesNotice extends \WicketAcc\WicketAcc
     /**
      * Create a published my-account page per missing slug.
      *
-     * @return array<string, int|\WP_Error> slug => new post ID or error
+     * The per-slug check-then-insert has a race window: a double-click or
+     * two simultaneous admins can both see a slug missing, and WP would
+     * suffix the loser's insert (organization-members-bulk-2) while the
+     * required slug stays missing. A short transient lock serializes runs.
+     *
+     * @return array<string, int|\WP_Error>|\WP_Error slug => new post ID or error, or WP_Error when creation is already in progress
      */
-    public function createMissingPages(): array
+    public function createMissingPages(): array|\WP_Error
     {
-        $created = [];
-
-        foreach ($this->missingPages() as $slug => $title) {
-            $created[$slug] = wp_insert_post([
-                'post_type' => 'my-account',
-                'post_status' => 'publish',
-                'post_title' => $title,
-                'post_name' => $slug,
-            ], true);
+        if (get_transient(self::CREATE_LOCK_TRANSIENT)) {
+            return new \WP_Error(
+                'wicket_acc_pages_in_progress',
+                __('Account Centre page creation is already in progress.', 'wicket-acc')
+            );
         }
 
-        return $created;
+        set_transient(self::CREATE_LOCK_TRANSIENT, 1, 15);
+
+        try {
+            $created = [];
+
+            foreach ($this->missingPages() as $slug => $title) {
+                $created[$slug] = wp_insert_post([
+                    'post_type' => 'my-account',
+                    'post_status' => 'publish',
+                    'post_title' => $title,
+                    'post_name' => $slug,
+                ], true);
+            }
+
+            return $created;
+        } finally {
+            delete_transient(self::CREATE_LOCK_TRANSIENT);
+        }
     }
 
     /**
@@ -133,6 +158,13 @@ class RequiredPagesNotice extends \WicketAcc\WicketAcc
     {
         if (!current_user_can('manage_options')) {
             return;
+        }
+
+        if (isset($_GET['wicket_acc_pages_busy'])) {
+            printf(
+                '<div class="notice notice-info is-dismissible"><p>%s</p></div>',
+                esc_html__('Account Centre: page creation is already in progress. Please wait a few seconds and reload.', 'wicket-acc')
+            );
         }
 
         $created = isset($_GET['wicket_acc_pages_created']) ? absint($_GET['wicket_acc_pages_created']) : null;
@@ -207,6 +239,12 @@ class RequiredPagesNotice extends \WicketAcc\WicketAcc
         check_admin_referer('wicket_acc_create_required_pages');
 
         $results = $this->createMissingPages();
+
+        if (is_wp_error($results)) {
+            $redirect = wp_get_referer() ?: admin_url();
+            wp_safe_redirect(add_query_arg(['wicket_acc_pages_busy' => '1'], $redirect));
+            exit;
+        }
 
         $created = 0;
         $failed = 0;

--- a/src/WicketORM/Helpers/TemplateHelper.php
+++ b/src/WicketORM/Helpers/TemplateHelper.php
@@ -63,6 +63,29 @@ class TemplateHelper extends Helper
     }
 
     /**
+     * Determine whether a membership cycle entry should be included in the organization list.
+     *
+     * @param array  $om_attrs  Membership attributes array (active, in_grace, starts_at, ends_at, etc.).
+     * @param array  $om_data   Full raw API entry data array.
+     * @param string $org_uuid  UUID of the organization being rendered.
+     * @return bool True if entry should be included, false otherwise.
+     */
+    public static function should_include_membership_cycle_entry(array $om_attrs, array $om_data = [], string $org_uuid = ''): bool
+    {
+        $is_active = !empty($om_attrs['active']);
+        $in_grace = !empty($om_attrs['in_grace']);
+        $include = $is_active || $in_grace;
+
+        return (bool) apply_filters(
+            'wicket/acc/orgman/membership_cycle_include_entry',
+            $include,
+            $om_attrs,
+            $om_data,
+            $org_uuid
+        );
+    }
+
+    /**
      * Detect if it's a template request for our org management system.
      *
      * @return bool

--- a/src/WicketORM/templates-partials/members-view-unified.php
+++ b/src/WicketORM/templates-partials/members-view-unified.php
@@ -309,6 +309,7 @@ $group_add_member_success_actions = "console.log('Group member added successfull
 if ($group_add_member_auto_close_on_success && $group_add_member_auto_close_delay_seconds > 0) {
     $group_add_member_success_actions .= " \$autoCloseCountdown = {$group_add_member_auto_close_delay_seconds};";
 }
+$clear_form_on_error = (bool) ($orgman_config['member_management']['forms']['add_member']['clear_form_on_error'] ?? false);
 $add_member_error_actions = "console.error('Failed to add member'); \$addMemberSubmitting = false; \$membersLoading = false; \$addMemberSuccess = false; \$autoCloseCountdown = 0;";
 if ($clear_form_on_error) {
     $add_member_error_actions .= " el.closest('form').reset();";

--- a/src/WicketORM/templates-partials/organization-list.php
+++ b/src/WicketORM/templates-partials/organization-list.php
@@ -678,13 +678,10 @@ if ($roster_mode === 'membership_cycle') {
              *
              * @return bool True to include the row; false to skip it.
              */
-            $_mc_include = $_mc_is_active || $_mc_in_grace;
-            $_mc_include = (bool) apply_filters(
-                'wicket/acc/orgman/membership_cycle_include_entry',
-                $_mc_include,
+            $_mc_include = \WicketORM\Helpers\TemplateHelper::should_include_membership_cycle_entry(
                 $_mc_om_attrs,
                 $_mc_om_data,
-                $_mc_oid
+                (string) $_mc_oid
             );
 
             if (!$_mc_include) {


### PR DESCRIPTION
https://app.asana.com/1/1138832104141584/task/1215417787812027
Product tracking: https://app.asana.com/1/1138832104141584/task/1216917808856765

The org-roster UI links to account pages a site may never have created. Helper::getMyAccountPageUrl() falls back to a home_url path that 404s, so a missing page is a user-facing break: ESCRS staging's "Bulk Upload" button 404ed exactly this way.

What changed:
- admin notice lists required my-account slugs with no published page, gated per feature (bulk upload page only when show_bulk_upload, contacts page only when contacts.enabled)
- "Create missing pages" button: admin-invoked, manage_options + nonce, inserts published pages for the missing slugs (no template meta needed, content injection is slug-keyed)
- wicket_acc/required-pages/slugs filter lets a tenant drop a slug it renamed or does not use
- nothing is created automatically; the action stays in admin hands

Tests: Warden `composer test:unit:account-centre` green. Covered: feature gating of required slugs, missing-page detection mirroring getMyAccountPageUrl, create-missing-only insertion shape.