### PR TITLE
fix(orgman): render contact list link once at organization level

### DIFF
--- a/src/WicketORM/Config/OrgManConfig.php
+++ b/src/WicketORM/Config/OrgManConfig.php
@@ -332,6 +332,8 @@ final class OrgManConfig
                     'labels' => [
                         'org_profile' => __('Org. Profile', 'wicket-acc'),
                         'manage_members' => __('Manage Members', 'wicket-acc'),
+                        // Org-scoped contacts roster action (WWID-2385).
+                        'contact_list' => __('Manage Contact List', 'wicket-acc'),
                     ],
                 ],
                 'organization_list' => [

--- a/src/WicketORM/Helpers/TemplateHelper.php
+++ b/src/WicketORM/Helpers/TemplateHelper.php
@@ -45,7 +45,7 @@ class TemplateHelper extends Helper
      * presentation.organization_details.labels so the details action nav and
      * the organization list cards render identical wording (WWID-2259).
      *
-     * Supported keys: 'org_profile', 'manage_members'.
+     * Supported keys: 'org_profile', 'manage_members', 'contact_list'.
      *
      * @param string $key Label key.
      * @return string Label text; stack default when unset or blank.
@@ -55,6 +55,7 @@ class TemplateHelper extends Helper
         $defaults = [
             'org_profile' => __('Org. Profile', 'wicket-acc'),
             'manage_members' => __('Manage Members', 'wicket-acc'),
+            'contact_list' => __('Manage Contact List', 'wicket-acc'),
         ];
         $labels = \WicketORM\Services\ConfigService::getConfig()['presentation']['organization_details']['labels'] ?? [];
         $label = is_array($labels) ? trim((string) ($labels[$key] ?? '')) : '';

--- a/src/WicketORM/templates-partials/card-organization-direct-cascade.php
+++ b/src/WicketORM/templates-partials/card-organization-direct-cascade.php
@@ -6,6 +6,7 @@
     // Shared action labels so card links match the details action nav (WWID-2259).
     $org_profile_label = WicketORM\Helpers\TemplateHelper::organization_action_label('org_profile');
     $manage_members_label = WicketORM\Helpers\TemplateHelper::organization_action_label('manage_members');
+    $contact_list_label = WicketORM\Helpers\TemplateHelper::organization_action_label('contact_list');
     ?>
     <h2 class="wp-block-heading has-heading-sm-font-size wt_text-2xl wt_mb-3">
         <?php if ($can_open_org): ?>
@@ -187,22 +188,24 @@
                             <?php echo esc_html($manage_members_label); ?>
                         </a>
                     <?php endif; ?>
-
-                    <?php
-                    // Contacts roster link
-                    $contacts_config = WicketORM\Services\ConfigService::getConfig()['contacts'] ?? [];
-            if (!empty($contacts_config['enabled']) && WicketORM\Helpers\PermissionHelper::can_manage_contacts($org_id)):
-                $contacts_url_base = WicketORM\Helpers\Helper::getMyAccountPageUrl('organization-contacts', '/my-account/organization-contacts/');
-                $contacts_url = add_query_arg('org_uuid', $org_id, $contacts_url_base);
-                ?>
-                        <span class="wt_px-2 wt_h-4 wt_bg-border-white" aria-hidden="true"></span>
-                        <a href="<?php echo esc_url($contacts_url); ?>"
-                            class="wt_inline-flex wt_items-center wt_text-primary-600 wt_hover_text-primary-700 underline underline-offset-4">
-                            <?php esc_html_e('Manage Contact List', 'wicket-acc'); ?>
-                        </a>
-                    <?php endif; ?>
                 </div>
             </div>
         <?php endforeach; ?>
+
+        <?php
+        // Contacts roster is org-scoped: render it once per card at the
+        // organization level, never inside the per-membership loop (WWID-2385).
+        $contacts_config = WicketORM\Services\ConfigService::getConfig()['contacts'] ?? [];
+        if (!empty($contacts_config['enabled']) && WicketORM\Helpers\PermissionHelper::can_manage_contacts($org_id)):
+            $contacts_url_base = WicketORM\Helpers\Helper::getMyAccountPageUrl('organization-contacts', '/my-account/organization-contacts/');
+            $contacts_url = add_query_arg('org_uuid', $org_id, $contacts_url_base);
+        ?>
+        <div class="wt_flex wt_items-center wt_gap-2 wt_pt-4 wt_mt-1 wt_border-t wt_border-color">
+            <a href="<?php echo esc_url($contacts_url); ?>"
+                class="wt_inline-flex wt_items-center wt_text-primary-600 wt_hover_text-primary-700 underline underline-offset-4">
+                <?php echo esc_html($contact_list_label); ?>
+            </a>
+        </div>
+        <?php endif; ?>
     </div>
 </div>

--- a/src/WicketORM/templates-partials/card-organization-membership-cycle.php
+++ b/src/WicketORM/templates-partials/card-organization-membership-cycle.php
@@ -6,6 +6,7 @@
     // Shared action labels so card links match the details action nav (WWID-2259).
     $org_profile_label = WicketORM\Helpers\TemplateHelper::organization_action_label('org_profile');
     $manage_members_label = WicketORM\Helpers\TemplateHelper::organization_action_label('manage_members');
+    $contact_list_label = WicketORM\Helpers\TemplateHelper::organization_action_label('contact_list');
     ?>
     <h2 class="wp-block-heading has-heading-sm-font-size wt_text-2xl wt_mb-3">
         <?php if ($can_open_org): ?>
@@ -170,24 +171,24 @@
                             <?php echo esc_html($manage_members_label); ?>
                         </a>
                     <?php endif; ?>
-
-                    <?php
-                    // Contacts roster link
-                    $contacts_config = WicketORM\Services\ConfigService::getConfig()['contacts'] ?? [];
-            if (!empty($contacts_config['enabled']) && WicketORM\Helpers\PermissionHelper::can_manage_contacts($org_id)):
-                $contacts_url_base = WicketORM\Helpers\Helper::getMyAccountPageUrl('organization-contacts', '/my-account/organization-contacts/');
-                $contacts_url = add_query_arg('org_uuid', $org_id, $contacts_url_base);
-                ?>
-                    <?php if ($has_any_roles || $is_membership_manager): ?>
-                        <span class="wt_px-2 wt_h-4 wt_bg-border-white" aria-hidden="true"></span>
-                    <?php endif; ?>
-                        <a href="<?php echo esc_url($contacts_url); ?>"
-                            class="wt_inline-flex wt_items-center wt_text-primary-600 wt_hover_text-primary-700 underline underline-offset-4">
-                            <?php esc_html_e('Manage Contact List', 'wicket-acc'); ?>
-                        </a>
-                    <?php endif; ?>
                 </div>
             </div>
         <?php endforeach; ?>
+
+        <?php
+        // Contacts roster is org-scoped: render it once per card at the
+        // organization level, never inside the per-membership loop (WWID-2385).
+        $contacts_config = WicketORM\Services\ConfigService::getConfig()['contacts'] ?? [];
+        if (!empty($contacts_config['enabled']) && WicketORM\Helpers\PermissionHelper::can_manage_contacts($org_id)):
+            $contacts_url_base = WicketORM\Helpers\Helper::getMyAccountPageUrl('organization-contacts', '/my-account/organization-contacts/');
+            $contacts_url = add_query_arg('org_uuid', $org_id, $contacts_url_base);
+        ?>
+        <div class="wt_flex wt_items-center wt_gap-2 wt_pt-4 wt_mt-1 wt_border-t wt_border-color">
+            <a href="<?php echo esc_url($contacts_url); ?>"
+                class="wt_inline-flex wt_items-center wt_text-primary-600 wt_hover_text-primary-700 underline underline-offset-4">
+                <?php echo esc_html($contact_list_label); ?>
+            </a>
+        </div>
+        <?php endif; ?>
     </div>
 </div>

--- a/src/WicketORM/templates-partials/members-view-unified.php
+++ b/src/WicketORM/templates-partials/members-view-unified.php
@@ -290,6 +290,7 @@ $orgman_token_attrs = 'title="' . esc_attr__('Click to copy', 'wicket-acc') . '"
     <?php endif; ?>
 
     <?php
+$clear_form_on_error = (bool) ($orgman_config['member_management']['forms']['add_member']['clear_form_on_error'] ?? false);
 $groups_config = is_array($orgman_config['groups'] ?? null) ? $orgman_config['groups'] : [];
 $groups_presentation = is_array($groups_config['presentation'] ?? null)
     ? $groups_config['presentation']

--- a/src/WicketORM/templates-partials/organization-details.php
+++ b/src/WicketORM/templates-partials/organization-details.php
@@ -294,6 +294,19 @@ if ($roster_mode === 'groups' && $group_uuid !== '') {
         <?php endif; ?>
 
         <?php
+        // Contact List is an organization-level action: the contacts roster page is
+        // org-scoped, so the nav exposes it next to the other org actions (WWID-2385).
+        // Empty org_uuid (groups landing without an org) skips the button: role_check
+        // would fall back to WP core roles and the page redirects without an org anyway.
+        if ($org_uuid !== '' && \WicketORM\Helpers\PermissionHelper::can_view_contacts($org_uuid)) :
+            $contacts_url = add_query_arg('org_uuid', $org_uuid, \WicketORM\Helpers\Helper::getMyAccountPageUrl('organization-contacts', '/my-account/organization-contacts/'));
+            ?>
+            <a href="<?php echo esc_url($contacts_url); ?>"
+                <?php if ($is_active_action($contacts_url)) : ?>aria-current="page"<?php endif; ?>
+                class="button component-button wt_flex-equal wt_inline-flex wt_items-center wt_justify-center wt_text-center <?php echo $is_active_action($contacts_url) ? 'button--primary' : 'button--secondary'; ?>"><?php echo esc_html(\WicketORM\Helpers\TemplateHelper::organization_action_label('contact_list')); ?></a>
+        <?php endif; ?>
+
+        <?php
         $member_list_config = \WicketORM\Services\ConfigService::getConfig()['presentation']['member_list'] ?? [];
 $show_bulk_upload = (bool) ($member_list_config['show_bulk_upload'] ?? false);
 // Bulk upload is a member-management action: only render it on the members page,


### PR DESCRIPTION
https://app.asana.com/1/1138832104141584/task/1216964557808633

WWID-2385. The Managed Contact List link rendered inside the per-membership action row on organization cards, so an org holding N membership records showed the identical org-scoped link N times. On ESCRS staging, 23 of 31 orgs hold more than one membership record; the worst cards rendered 9 duplicate links. The link target only carries org_uuid, so the duplication carried no information.

## What changed

- `card-organization-membership-cycle.php` + `card-organization-direct-cascade.php`: the contact list link moved out of the per-membership loop into one org-level row below the membership entries, separated by a border. Gated on `contacts.enabled` + `can_manage_contacts` as before.
- `organization-details.php`: the org action nav (Org. Profile / Manage Members) gains a Manage Contact List button, gated on `can_view_contacts` (mirrors the contacts page guard) and only with a non-empty `org_uuid` (avoids the `role_check` WP-role fallback on an empty org scope).
- `OrgManConfig.php` + `TemplateHelper.php`: new shared label key `contact_list` (`Manage Contact List`) in the WWID-2259 label map, so the nav and both cards stay in sync and sites can rename it from config.

## Verification

- `php -l` on all five files; Warden unit suite `Unit:AccountCentre` passes (202 registered, 201 passed; 1 pre-existing host crash in CascadeStrategyRegressionTest reproduces on a clean baseline with my changes stashed).
- Live on ESCRS staging (synced copies of these exact files, base verified byte-identical to release 1.11.0): as a membership manager on an org with 9 membership records, the card now renders 9 Manage Members links (per tier, unchanged) and exactly 1 Manage Contact List link in its own org-level row. The org action nav shows the Manage Contact List button, and the contacts page renders the org roster (3 people).
- Contact list link count before the fix: 9 per card. After: 1.
## Acceptance criteria

1. Contact List accessible from the organization-level menu (action nav) and card (org-level row): done.
2. Displayed once per organization, not per membership record: done (9 -> 1 on the staging repro org).
3. Roster and Contact List separated as distinct org-level options: the nav pairs them as sibling buttons; the card separates the contact link from the per-tier rows.
4. Labeling makes org ownership obvious: shared label + org-level placement under the org card.