### PR TITLE
fix(orgman): keep org UUID in group member custom data

### DIFF
--- a/src/WicketORM/Services/GroupService.php
+++ b/src/WicketORM/Services/GroupService.php
@@ -930,21 +930,11 @@ class GroupService
                     $group_item = $included_lookup['groups'][$membership_group];
                     $org_id = $group_item['relationships']['organization']['data']['id'] ?? $org_id;
                 }
+                // Keep the UUID here. It flows into custom_data_field.value, which tenant
+                // schemas (e.g. IAA) validate as an enum of org UUIDs; a resolved legal
+                // name fails validation. Scope matching expands UUIDs to name tokens in
+                // memberMatchesOrgScope(), so names need no pre-resolution.
                 $org_identifier = $this->extractOrgIdentifier($membership, $org_id);
-
-                // If org_identifier is a UUID, try to resolve a name for better association matching.
-                if ($org_identifier === $org_id && function_exists('wicket_get_organization')) {
-                    try {
-                        $org_response = wicket_get_organization($org_id);
-                        $org_attrs = is_array($org_response) ? ($org_response['data']['attributes'] ?? []) : [];
-                        $resolved_name = (string) ($org_attrs['legal_name'] ?? $org_attrs['legal_name_en'] ?? $org_attrs['name'] ?? '');
-                        if ($resolved_name !== '') {
-                            $org_identifier = $resolved_name;
-                        }
-                    } catch (\Throwable $e) {
-                        // Fallback to UUID
-                    }
-                }
 
                 $result = [
                     'allowed' => true,


### PR DESCRIPTION
## Context
Task ID: WWID-2381
Task Link: https://app.asana.com/1/1138832104141584/task/1217590790076653
Related PRs: https://github.com/industrialdev/wicket-wp-base-plugin/pull/46

## What
Adding a member to an org group fails on a tenant whose MDP group-member `custom_data_field` schema validates `value.name` against an enum of org UUIDs. The modal spins forever.

## Why
`canManageGroup()` rewrote a UUID org identifier into the org legal name for association matching. That value feeds `buildCustomDataField()`, which writes `custom_data_field.value.name`. A legal name never matches the schema's UUID enum, so MDP returns 422 on every add. Staging logs show the 422 recurring on both Aug 18 and Sep 1, for any group under the org.

## How
Removed the UUID-to-name rewrite in `GroupService::canManageGroup()` so the identifier stays a UUID end to end:

- The write becomes `{name: <org uuid>}`, which the tenant schema accepts (the org's own UUID is in the enum).
- Scope matching does not regress: `resolveScopeTokens()` expands a UUID target into uuid + legal/name variant tokens and intersects. Pre-fix, a name target skipped expansion entirely (names are never expanded back to uuids), so the uuid target is a superset of the old match set.
- `buildCustomDataField()` has exactly one caller (`GroupsStrategy::addMember()`); its `removeMember()` and the read/list templates only scope-match, so they inherit the same superset behavior.
- Only one tenant runs `membership.strategy = groups` today, which bounds the blast radius to this code path.

Companion fix in the linked wicket-wp-base-plugin PR: the 422 surfaced as HTTP 500 + infinite spinner because the helper stored the decoded JSON:API error array as the WP_Error message, and `DatastarSSE::renderError(string)` threw an uncaught TypeError on it.